### PR TITLE
Protect PrimitiveType from a bad usage.

### DIFF
--- a/include/xtypes/PrimitiveType.hpp
+++ b/include/xtypes/PrimitiveType.hpp
@@ -70,6 +70,9 @@ private:
         : DynamicType(PrimitiveTypeKindTrait<T>::kind, PrimitiveTypeKindTrait<T>::name)
     {}
 
+    PrimitiveType(const PrimitiveType& other) = delete;
+    PrimitiveType(PrimitiveType&& other) = delete;
+
     virtual size_t memory_size() const override
     {
         return sizeof(T);


### PR DESCRIPTION
The instances of PrimitiveType must be uniques in the program. This PR disable the copy and move methods to avoid bad usage from the user that could break the program.