### PR TITLE
Removed string and wstring methods.

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,12 +182,14 @@ This compatibility can be checked with `is_compatible` function.
 #### Internal data access
 Depending on the type, the `DynamicData` will behave in different ways.
 The following methods are available when:
-1. `DynamicData` represents a `PrimitiveType` (of `int32_t` as example):
+1. `DynamicData` represents a `PrimitiveType`, `StringType` or `WStringType` (of `int32_t` as example):
     ```c++
     data.value(42); //sets the value to 42
     data = 23; // Analogous to the one above, assignment from primitive, sets the value to 23
     int32_t value = data.value<int32_t>(); //read the value
     int32_t value = data; //By casting operator
+    data = "Hello again!"; // set string value
+    data = L"Hello again! \u263A"; // set string value
     ```
 1. `DynamicData` represents an `AggregationType`
     ```c++
@@ -206,20 +208,6 @@ The following methods are available when:
     data[2] = dynamic_data_representing_a_value;
     WritableDynamicDataRef ref = data[2]; //references to a DynamicData that represents a collection
     size_t size = data.size(); //size of collection
-    ```
-1. `DynamicData` represents a `StringType`.
-    Same as `CollectionType` plus:
-    ```c++
-    data = "Hello again!"; // set string value
-    const std::string& s1 = data.value<std::string>(); //read the string value
-    const std::string& s2 = data.string(); // shortcut version for string
-    ```
-1. `DynamicData` represents a `WStringType`.
-    Same as `CollectionType` plus:
-    ```c++
-    data = L"Hello again! \u263A"; // set string value
-    const std::wstring& s1 = data.value<std::wstring>(); //read the string value
-    const std::wstring& s2 = data.wstring(); // shortcut version for string
     ```
 1. `DynamicData` represents a `SequenceType`.
     Same as `CollectionType` plus:

--- a/include/xtypes/DynamicData.hpp
+++ b/include/xtypes/DynamicData.hpp
@@ -89,24 +89,6 @@ public:
         return *reinterpret_cast<T*>(instance_);
     }
 
-    /// \brief Returns a value as string.
-    /// \pre The DynamicData must represent StringType.
-    /// \returns the value stored in the DynamicData.
-    const std::string& string() const
-    {
-        assert(type_.kind() == TypeKind::STRING_TYPE);
-        return value<std::string>();
-    }
-
-    /// \brief Returns a value as string of wchars.
-    /// \pre The DynamicData must represent WStringType.
-    /// \returns the value stored in the DynamicData.
-    const std::wstring& wstring() const
-    {
-        assert(type_.kind() == TypeKind::WSTRING_TYPE);
-        return value<std::wstring>();
-    }
-
     /// \brief Member access operator by name.
     /// \param[in] member_name Name of the member to access.
     /// \pre The DynamicData must represent an AggregationType.
@@ -302,18 +284,6 @@ public:
     const T& value()
     {
         return ReadableDynamicDataRef::value<T>();
-    }
-
-    /// \brief See ReadableDynamicDataRef::string()
-    const std::string& string()
-    {
-        return ReadableDynamicDataRef::string();
-    }
-
-    /// \brief See ReadableDynamicDataRef::wstring()
-    const std::wstring& wstring()
-    {
-        return ReadableDynamicDataRef::wstring();
     }
 
     /// \brief See ReadableDynamicDataRef::operator[]()

--- a/include/xtypes/DynamicData.hpp
+++ b/include/xtypes/DynamicData.hpp
@@ -263,7 +263,7 @@ public:
     WritableDynamicDataRef& operator = (
             const std::string& other)
     {
-        string(other);
+        value<std::string>(other);
         return *this;
     }
 
@@ -271,7 +271,7 @@ public:
     WritableDynamicDataRef& operator = (
             const std::wstring& other)
     {
-        wstring(other);
+        value<std::wstring>(other);
         return *this;
     }
 
@@ -501,6 +501,28 @@ public:
         type_.destroy_instance(instance_);
         type_.copy_instance(instance_, p_instance(other));
         return *this;
+    }
+
+    /// \brief See WritableDynamicDataRef::operator =()
+    template<typename T, class = PrimitiveOrString<T>>
+    WritableDynamicDataRef& operator = (
+            const T& other)
+    {
+        return WritableDynamicDataRef::operator=(other);
+    }
+
+    /// \brief See WritableDynamicDataRef::operator =()
+    WritableDynamicDataRef& operator = (
+            const std::string& other)
+    {
+        return WritableDynamicDataRef::operator=(other);
+    }
+
+    /// \brief See WritableDynamicDataRef::operator =()
+    WritableDynamicDataRef& operator = (
+            const std::wstring& other)
+    {
+        return WritableDynamicDataRef::operator=(other);
     }
 
     virtual ~DynamicData() override

--- a/test/unitary/main.cpp
+++ b/test/unitary/main.cpp
@@ -422,7 +422,7 @@ DynamicData create_dynamic_data(long double pi, StructType& the_struct, StructTy
     for(int i = 0; i < STRUCTS_SIZE; ++i) // creating "sequence"
     {
         DynamicData tmp_data(inner_struct);
-        tmp_data["inner_string"].string(INNER_STRING_VALUE);
+        tmp_data["inner_string"] = INNER_STRING_VALUE;
         tmp_data["inner_float"].value<float>(FLOAT);
         for (int j = 0; j < STRUCTS_SIZE; ++j) // creating "sequence.inner_sequence_string"
         {
@@ -432,7 +432,7 @@ DynamicData create_dynamic_data(long double pi, StructType& the_struct, StructTy
         for (int j = 0; j < STRUCTS_SIZE; ++j) // creating "sequence.inner_sequence_struct"
         {
             DynamicData tmp_inner_data(second_inner_struct);
-            tmp_inner_data["second_inner_string"].string(SECOND_INNER_STRING);
+            tmp_inner_data["second_inner_string"] = SECOND_INNER_STRING;
             tmp_inner_data["second_inner_uint32_t"].value<uint32_t>(UINT32);
             for(int k = 0; k < STRUCTS_SIZE; ++k) //creating "sequence.inner_sequence_struct.second_inner_array"
             {
@@ -479,12 +479,12 @@ TEST (DynamicData, cascade_construction)
     for (int i = 0; i < CHECKS_NUMBER; ++i)
     {
         size_t idx_4 = lrand48()%int(STRUCTS_SIZE);
-        EXPECT_EQ(INNER_STRING_VALUE, the_data["sequence"][idx_4]["inner_string"].string());
+        EXPECT_EQ(INNER_STRING_VALUE, the_data["sequence"][idx_4]["inner_string"].value<std::string>());
         EXPECT_EQ(FLOAT, the_data["sequence"][idx_4]["inner_float"].value<float>());
         size_t idx_3 = lrand48()%int(STRUCTS_SIZE);
-        EXPECT_EQ(INNER_SEQUENCE_STRING, the_data["sequence"][idx_4]["inner_sequence_string"][idx_3].string());
+        EXPECT_EQ(INNER_SEQUENCE_STRING, the_data["sequence"][idx_4]["inner_sequence_string"][idx_3].value<std::string>());
         size_t idx_2 = lrand48()%int(STRUCTS_SIZE);
-        EXPECT_EQ(SECOND_INNER_STRING, the_data["sequence"][idx_4]["inner_sequence_struct"][idx_2]["second_inner_string"].string());
+        EXPECT_EQ(SECOND_INNER_STRING, the_data["sequence"][idx_4]["inner_sequence_struct"][idx_2]["second_inner_string"].value<string>());
         EXPECT_EQ(UINT32, the_data["sequence"][idx_4]["inner_sequence_struct"][idx_2]["second_inner_uint32_t"].value<uint32_t>());
 
         size_t arr_idx_3 = lrand48()%int(STRUCTS_SIZE);
@@ -507,10 +507,10 @@ TEST (DynamicData, curious_interactions)
 
     StringType str;
     DynamicData dstr(str);
-    dstr.string("all_this_stuff");
+    dstr = "all_this_stuff";
 
     the_data["seq"].push(dstr);
-    EXPECT_EQ("all_this_stuff", the_data["seq"][0].string());
+    EXPECT_EQ("all_this_stuff", the_data["seq"][0].value<std::string>());
 }
 
 TEST (DynamicType, testing_is_compatible_string_no_bound)
@@ -824,7 +824,7 @@ TEST (DynamicData, test_equality_complex_struct)
     st.add_member(Member("seqstring", seq));
     st.add_member(Member("string", str));
     DynamicData d1(st);
-    d1["string"].string("sono io che sono qui");
+    d1["string"] = "sono io che sono qui";
 
     for(int i=0; i < 15; ++i)
     {
@@ -847,8 +847,8 @@ TEST (DynamicType , wstring_and_wstring_struct)
     DynamicData d(wst);
     DynamicData dd(st);
 
-    d.wstring(L"sadfsfdasdf");
-    dd.string("sadfsfdasdf");
+    d = L"sadfsfdasdf";
+    dd = "sadfsfdasdf";
 
     EXPECT_EQ( TypeConsistency::NONE, wst.is_compatible(st) );
     EXPECT_EQ( TypeConsistency::NONE, st.is_compatible(wst) );
@@ -919,10 +919,10 @@ TEST (QoS, string)
     EXPECT_EQ(TypeConsistency::IGNORE_STRING_BOUNDS, t.is_compatible(s));
 
     DynamicData ds(s);
-    ds.string("12345678901234567890");
+    ds = "12345678901234567890";
 
     DynamicData dt(t);
-    dt.string("1234567890");
+    dt = "1234567890";
 
     DynamicData dt_as_ds(dt, s);
     EXPECT_EQ(10, dt_as_ds.size());
@@ -942,10 +942,10 @@ TEST (QoS, wstring)
     EXPECT_EQ(TypeConsistency::IGNORE_STRING_BOUNDS, t.is_compatible(s));
 
     DynamicData ds(s);
-    ds.wstring(L"12345678901234567890");
+    ds = L"12345678901234567890";
 
     DynamicData dt(t);
-    dt.wstring(L"1234567890");
+    dt = L"1234567890";
 
     DynamicData dt_as_ds(dt, s);
     EXPECT_EQ(10, dt_as_ds.size());


### PR DESCRIPTION
- Rationale: Since `= operator` and `cast operator` allow you to manage easily the strings, the `string` and `wstring` methods are no longer necessary. It specify the type is needed, the `value<std::string>()` way can be called."

- Fixed a bug when try to assign a primitive/string/wstring from a DynamicData and not from a WritableDynamicData.