### PR TITLE
Feature/modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,24 +175,24 @@ Modules are equivalent to C++ namespaces. They can store sets of StructType, Con
 They allow organizing types into different scopes, allowing scope solving when accessing the stored types.
 ```c++
 Module root;
-Module& submod_A = root.create_submodule("A");
-Module& submod_B = root.create_submodule("B");
-Module& submod_AA = submod_A.create_submodule("A");
-root.set_struct(inner);
-submod_AA.set_struct(outer);
+Module& submod_a = root.create_submodule("a");
+Module& submod_b = root.create_submodule("b");
+Module& submod_aa = submod_a.create_submodule("a");
+root.structure(inner);
+submod_aa.structure(outer);
 
 std::cout << std::boolalpha;
-std::cout << "Does A::A::OuterType exists?: " << root.has_struct("A::A::OuterType") << std::endl;   // true
-std::cout << "Does ::InnerType exists?: " << root.has_struct("::InnerType") << std::endl;           // true
-std::cout << "Does InnerType exists?: " << root.has_struct("InnerType") << std::endl;               // true
-std::cout << "Does OuterType exists?: " << root.has_struct("OuterType") << std::endl;               // false
+std::cout << "Does a::a::OuterType exists?: " << root.has_structure("a::a::OuterType") << std::endl;   // true
+std::cout << "Does ::InnerType exists?: " << root.has_structure("::InnerType") << std::endl;           // true
+std::cout << "Does InnerType exists?: " << root.has_structure("InnerType") << std::endl;               // true
+std::cout << "Does OuterType exists?: " << root.has_structure("OuterType") << std::endl;               // false
 
-DynamicData module_data(root["A"]["A"].get_struct("OuterType")); // ::A::A::OuterType
+DynamicData module_data(root["a"]["a"].structure("OuterType")); // ::a::a::OuterType
 module_data["om3"] = "This is a string.";
 ```
 As can be seen in the example, a module allows the user to access their internal definitions in two ways:
-Accessing directly using a scope name (`root.has_struct("A::A::OuterType")`), or navigating manually through the
-inner modules (`root["A"]["A"].get_struct("OuterType")`).
+Accessing directly using a scope name (`root.structure("a::a::OuterType")`), or navigating manually through the
+inner modules (`root["a"]["a"].structure("OuterType")`).
 
 ### Data instance
 #### Initialization

--- a/README.md
+++ b/README.md
@@ -169,6 +169,31 @@ The returned `TypeConsistency` is going to be a subset of the following *QoS pol
 
 Note: `TypeConsistency` is an enum with `|` and `&` operators overrided to manage it as a set of QoS policies.
 
+### Module
+Modules are equivalent to C++ namespaces. They can store sets of StructType, Constants and other Modules
+(as submodules).
+They allow organizing types into different scopes, allowing scope solving when accessing the stored types.
+```c++
+Module root;
+Module& submod_A = root.create_submodule("A");
+Module& submod_B = root.create_submodule("B");
+Module& submod_AA = submod_A.create_submodule("A");
+root.set_struct(inner);
+submod_AA.set_struct(outer);
+
+std::cout << std::boolalpha;
+std::cout << "Does A::A::OuterType exists?: " << root.has_struct("A::A::OuterType") << std::endl;   // true
+std::cout << "Does ::InnerType exists?: " << root.has_struct("::InnerType") << std::endl;           // true
+std::cout << "Does InnerType exists?: " << root.has_struct("InnerType") << std::endl;               // true
+std::cout << "Does OuterType exists?: " << root.has_struct("OuterType") << std::endl;               // false
+
+DynamicData module_data(root["A"]["A"].get_struct("OuterType")); // ::A::A::OuterType
+module_data["om3"] = "This is a string.";
+```
+As can be seen in the example, a module allows the user to access their internal definitions in two ways:
+Accessing directly using a scope name (`root.has_struct("A::A::OuterType")`), or navigating manually through the
+inner modules (`root["A"]["A"].get_struct("OuterType")`).
+
 ### Data instance
 #### Initialization
 To instantiate a data, only is necessary a `DynamicType`:

--- a/examples/complex_type.cpp
+++ b/examples/complex_type.cpp
@@ -1,4 +1,5 @@
 #include <xtypes/xtypes.hpp>
+#include <xtypes/Module.hpp>
 
 #include <iostream>
 
@@ -48,6 +49,19 @@ int main()
     data["om8"][1] = data["om2"];                          //ArrayType(inner)
 
     std::cout << data.to_string() << std::endl; //See to_string() implementation as an example of data instrospection
+
+    Module root;
+    Module& submod_A = root.create_submodule("A");
+    Module& submod_B = root.create_submodule("B");
+    Module& submod_AA = submod_A.create_submodule("A");
+    root.set_struct(inner);
+    submod_AA.set_struct(outer);
+
+    std::cout << std::boolalpha;
+    std::cout << "Does A::A::OuterType exists?: " << root.has_struct("A::A::OuterType") << std::endl;
+    std::cout << "Does ::InnerType exists?: " << root.has_struct("::InnerType") << std::endl;
+    std::cout << "Does InnerType exists?: " << root.has_struct("InnerType") << std::endl;
+    std::cout << "Does OuterType exists?: " << root.has_struct("OuterType") << std::endl;
 
     return 0;
 }

--- a/examples/complex_type.cpp
+++ b/examples/complex_type.cpp
@@ -51,19 +51,19 @@ int main()
     std::cout << data.to_string() << std::endl; //See to_string() implementation as an example of data instrospection
 
     Module root;
-    Module& submod_A = root.create_submodule("A");
-    Module& submod_B = root.create_submodule("B");
-    Module& submod_AA = submod_A.create_submodule("A");
-    root.set_struct(inner);
-    submod_AA.set_struct(outer);
+    Module& submod_a = root.create_submodule("a");
+    Module& submod_b = root.create_submodule("b");
+    Module& submod_aa = submod_a.create_submodule("a");
+    root.structure(inner);
+    submod_aa.structure(outer);
 
     std::cout << std::boolalpha;
-    std::cout << "Does A::A::OuterType exists?: " << root.has_struct("A::A::OuterType") << std::endl;
-    std::cout << "Does ::InnerType exists?: " << root.has_struct("::InnerType") << std::endl;
-    std::cout << "Does InnerType exists?: " << root.has_struct("InnerType") << std::endl;
-    std::cout << "Does OuterType exists?: " << root.has_struct("OuterType") << std::endl;
+    std::cout << "Does a::a::OuterType exists?: " << root.has_structure("a::a::OuterType") << std::endl;
+    std::cout << "Does ::InnerType exists?: " << root.has_structure("::InnerType") << std::endl;
+    std::cout << "Does InnerType exists?: " << root.has_structure("InnerType") << std::endl;
+    std::cout << "Does OuterType exists?: " << root.has_structure("OuterType") << std::endl;
 
-    DynamicData module_data(root["A"]["A"].get_struct("OuterType")); // ::A::A::OuterType
+    DynamicData module_data(root["a"]["a"].structure("OuterType")); // ::a::a::OuterType
     module_data["om3"] = "This is a string.";
 
     return 0;

--- a/examples/complex_type.cpp
+++ b/examples/complex_type.cpp
@@ -15,7 +15,7 @@ int main()
         };
     )";
 
-    std::map<std::string, DynamicType::Ptr> from_idl = idl::parse(idl_spec).structs;
+    std::map<std::string, DynamicType::Ptr> from_idl = idl::parse(idl_spec).module->get_all_types();
     const StructType& inner = static_cast<const StructType&>(*from_idl.at("InnerType"));
 
     StructType outer("OuterType");
@@ -62,6 +62,9 @@ int main()
     std::cout << "Does ::InnerType exists?: " << root.has_struct("::InnerType") << std::endl;
     std::cout << "Does InnerType exists?: " << root.has_struct("InnerType") << std::endl;
     std::cout << "Does OuterType exists?: " << root.has_struct("OuterType") << std::endl;
+
+    DynamicData module_data(root["A"]["A"].get_struct("OuterType")); // ::A::A::OuterType
+    module_data["om3"] = "This is a string.";
 
     return 0;
 }

--- a/include/xtypes/Module.hpp
+++ b/include/xtypes/Module.hpp
@@ -255,13 +255,24 @@ public:
         return false;
     }
 
-    bool constant(
+    bool create_constant(
             const std::string& name,
-            const DynamicData& value)
+            const DynamicData& value,
+            bool replace = false)
     {
         if (name.find("::") != std::string::npos)
         {
             return false; // Cannot add a symbol with scoped name.
+        }
+
+        if (replace)
+        {
+            auto it = constants.find(name);
+            if (it != constants.end())
+            {
+                constants.erase(it);
+                constants_types.erase(constants_types.find(name));
+            }
         }
 
         auto inserted = constants_types.emplace(name, value.type());

--- a/include/xtypes/Module.hpp
+++ b/include/xtypes/Module.hpp
@@ -1,0 +1,328 @@
+/*
+ * Copyright 2019, Proyectos y Sistemas de Mantenimiento SL (eProsima).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+#ifndef EPROSIMA_XTYPES_MODULE_HPP_
+#define EPROSIMA_XTYPES_MODULE_HPP_
+
+#include <xtypes/xtypes.hpp>
+
+namespace eprosima {
+namespace xtypes {
+
+class Module
+{
+protected:
+    using PairModuleSymbol = std::pair<const Module*, std::string>;
+
+public:
+    Module()
+        : outer(nullptr)
+        , name_("")
+    {}
+
+    Module& create_submodule(
+            const std::string& submodule)
+    {
+        Module* new_module = new Module(this, submodule);
+        auto result = inner.emplace(submodule, new_module);
+        //auto result = inner.emplace(submodule, std::make_shared<Module>(this, submodule));
+        return *result.first->second.get();
+    }
+
+    Module& operator [] (
+            const std::string& submodule)
+    {
+        return *inner[submodule];
+    }
+
+    bool emplace(
+            std::shared_ptr<Module>&& module)
+    {
+        if (module->name_.find("::") != std::string::npos)
+        {
+            return false; // Cannot add a module with scoped name.
+        }
+        auto result = inner.emplace(module->name_, std::move(module));
+        return result.second;
+    }
+
+    const std::string& name() const
+    {
+        return name_;
+    }
+
+    std::string scope()
+    {
+        if (outer != nullptr && !outer->scope().empty())
+        {
+            return outer->scope() + "::" + name_;
+        }
+        return name_;
+    }
+
+    bool has_symbol(
+            const std::string& ident,
+            bool extend = true) const
+    {
+        size_t n_elems = structs.count(ident); // + constants.count(ident) + members.count(ident) + types.count(ident);
+        if (n_elems > 0)
+        {
+            return true;
+        }
+        if (extend && outer != nullptr)
+        {
+            return outer->has_symbol(ident, extend);
+        }
+        return false;
+    }
+
+    bool has_struct(
+            const std::string& name) const
+    {
+        // Solve scope
+        PairModuleSymbol module = resolve_scope(name);
+        if (module.first == nullptr)
+        {
+            return false;
+        }
+        return module.first->structs.count(module.second) > 0;
+    }
+
+    const StructType& get_struct(
+            const std::string& name) const
+    {
+        // Solve scope
+        PairModuleSymbol module = resolve_scope(name);
+        if (module.first == nullptr)
+        {
+            // This will fail
+            return static_cast<const StructType&>(*structs.end()->second);
+        }
+
+        auto it = module.first->structs.find(module.second);
+        if (it != module.first->structs.end())
+        {
+            return static_cast<const StructType&>(*it->second);
+        }
+        // This will fail
+        return static_cast<const StructType&>(*structs.end()->second);
+    }
+
+    bool set_struct(
+            const StructType& struct_type)
+    {
+        if (struct_type.name().find("::") != std::string::npos)
+        {
+            return false; // Cannot add a symbol with scoped name.
+        }
+
+        auto result = structs.emplace(struct_type.name(), struct_type);
+        return result.second;
+    }
+
+    bool set_struct(
+            StructType&& struct_type)
+    {
+        if (struct_type.name().find("::") != std::string::npos)
+        {
+            return false; // Cannot add a symbol with scoped name.
+        }
+
+        auto result = structs.emplace(struct_type.name(), std::move(struct_type));
+        return result.second;
+    }
+
+    // TODO has, get and set of:
+    // enums, bitmasks and unions
+
+    std::map<std::string, DynamicType::Ptr> get_all_types() const
+    {
+        std::map<std::string, DynamicType::Ptr> result;
+        fill_all_types(result);
+        return result;
+    }
+
+    void fill_all_types(
+            std::map<std::string, DynamicType::Ptr>& map) const
+    {
+        map.insert(structs.begin(), structs.end());
+        for (const auto& pair : inner)
+        {
+            pair.second->fill_all_types(map);
+        }
+    }
+
+    DynamicData get_constant(
+            const std::string& name) const
+    {
+        // Solve scope
+        PairModuleSymbol module = resolve_scope(name);
+        if (module.first == nullptr)
+        {
+            return DynamicData(primitive_type<bool>());
+        }
+
+        auto it = module.first->constants.find(module.second);
+        if (it != module.first->constants.end())
+        {
+            return it->second;
+        }
+
+        return DynamicData(primitive_type<bool>());
+    }
+
+    bool has_constant(
+            const std::string& name) const
+    {
+        // Solve scope
+        PairModuleSymbol module = resolve_scope(name);
+        if (module.first == nullptr)
+        {
+            return false;
+        }
+
+        auto it = module.first->constants.find(module.second);
+        if (it != module.first->constants.end())
+        {
+            return true;
+        }
+
+        return false;
+    }
+
+    bool set_constant(
+            const std::string& name,
+            const DynamicData& value)
+    {
+        if (name.find("::") != std::string::npos)
+        {
+            return false; // Cannot add a symbol with scoped name.
+        }
+
+        auto inserted = constants_types.emplace(name, value.type());
+        if (inserted.second)
+        {
+            DynamicData temp(*(inserted.first->second));
+            temp = value;
+            auto result = constants.emplace(name, temp);
+            return result.second;
+        }
+        return false;
+    }
+
+protected:
+    std::map<std::string, DynamicType::Ptr> constants_types;
+    std::map<std::string, DynamicData> constants;
+    std::map<std::string, DynamicType::Ptr> structs;
+    //std::map<std::string, std::shared_ptr<AnnotationType>> annotations;
+    Module* outer;
+    std::map<std::string, std::shared_ptr<Module>> inner;
+    std::string name_;
+
+    Module(
+            Module* outer,
+            const std::string& name)
+        : outer(outer)
+        , name_(name)
+    {
+    }
+
+    // Auxiliar method to resolve scoped. It will return the Module up to the last "::" by calling
+    // recursively resolving each scoped name, looking for the scope path, and the symbol name without the scope.
+    // If the path cannot be resolved, it will return nullptr as path, and the full given symbol name.
+    PairModuleSymbol resolve_scope(
+            const std::string& symbol_name) const
+    {
+        return resolve_scope(symbol_name, symbol_name, true);
+    }
+
+    PairModuleSymbol resolve_scope(
+            const std::string& symbol_name,
+            const std::string& original_name,
+            bool first = false) const
+    {
+        if (!first && symbol_name == original_name)
+        {
+            // Loop trying to resolve the name. Abort failing.
+            PairModuleSymbol pair;
+            pair.first = nullptr;
+            pair.second = original_name;
+            return pair;
+        }
+
+        std::string name = symbol_name;
+        // Solve scope
+        if (symbol_name.find("::") != std::string::npos) // It is an scoped name
+        {
+            if (symbol_name.find("::") == 0) // Looking for root
+            {
+                if (outer == nullptr) // We are the root, now go down.
+                {
+                    return resolve_scope(symbol_name.substr(2), original_name);
+                }
+                else // We are not the root, go up, with the original name.
+                {
+                    return outer->resolve_scope(original_name, original_name, true);
+                }
+            }
+            else // not looking for root
+            {
+                std::string inner_scope = symbol_name.substr(0, symbol_name.find("::"));
+                // Maybe the current scope its me?
+                if (inner_scope == name_)
+                {
+                    std::string innest_scope = inner_scope.substr(0, inner_scope.find("::"));
+                    if (inner.count(innest_scope) > 0)
+                    {
+                        std::string inner_name = symbol_name.substr(symbol_name.find("::") + 2);
+                        const auto& it = inner.find(innest_scope);
+                        PairModuleSymbol result = it->second->resolve_scope(inner_name, original_name);
+                        if (result.first != nullptr)
+                        {
+                            return result;
+                        }
+                    }
+                }
+                // Do we have a inner scope that matches?
+                if (inner.count(inner_scope) > 0)
+                {
+                    std::string inner_name = symbol_name.substr(symbol_name.find("::") + 2);
+                    const auto& it = inner.find(inner_scope);
+                    return it->second->resolve_scope(inner_name, original_name);
+                }
+                // Try going back
+                if (outer != nullptr && first)
+                {
+                    return outer->resolve_scope(original_name, original_name, true);
+                }
+                // Unknown scope
+                PairModuleSymbol pair;
+                pair.first = nullptr;
+                pair.second = original_name;
+                return pair;
+            }
+        }
+
+        return std::make_pair<const Module*, std::string>(this, std::move(name));
+    }
+
+};
+
+} // xtypes
+} // eprosima
+
+#endif // EPROSIMA_XTYPES_MODULE_HPP_

--- a/include/xtypes/Module.hpp
+++ b/include/xtypes/Module.hpp
@@ -39,11 +39,10 @@ public:
     {
         Module* new_module = new Module(this, submodule);
         auto result = inner.emplace(submodule, new_module);
-        //auto result = inner.emplace(submodule, std::make_shared<Module>(this, submodule));
         return *result.first->second.get();
     }
 
-    std::shared_ptr<Module> get_submodule(
+    std::shared_ptr<Module> submodule(
             const std::string& submodule)
     {
         return inner[submodule];
@@ -62,6 +61,13 @@ public:
         return *inner[submodule];
     }
 
+    const Module& operator [] (
+            const std::string& submodule) const
+    {
+        return *inner.at(submodule);
+    }
+
+    /* TODO - Probably should be removed.
     bool emplace(
             std::shared_ptr<Module>&& module)
     {
@@ -73,6 +79,7 @@ public:
         auto result = inner.emplace(module->name_, std::move(module));
         return result.second;
     }
+    */
 
     const std::string& name() const
     {
@@ -104,7 +111,7 @@ public:
         return false;
     }
 
-    bool has_struct(
+    bool has_structure(
             const std::string& name) const
     {
         // Solve scope
@@ -116,7 +123,7 @@ public:
         return module.first->structs.count(module.second) > 0;
     }
 
-    const StructType& get_struct(
+    const StructType& structure(
             const std::string& name) const
     {
         // Solve scope
@@ -136,7 +143,7 @@ public:
         return static_cast<const StructType&>(*structs.end()->second);
     }
 
-    StructType& get_struct(
+    StructType& structure(
             const std::string& name)
     {
         // Solve scope
@@ -156,7 +163,7 @@ public:
         return static_cast<StructType&>(const_cast<DynamicType&>(*structs.end()->second));
     }
 
-    bool set_struct(
+    bool structure(
             const StructType& struct_type)
     {
         if (struct_type.name().find("::") != std::string::npos)
@@ -168,7 +175,7 @@ public:
         return result.second;
     }
 
-    bool set_struct(
+    bool structure(
             StructType&& struct_type,
             bool replace = false)
     {
@@ -210,7 +217,7 @@ public:
         }
     }
 
-    DynamicData get_constant(
+    DynamicData constant(
             const std::string& name) const
     {
         // Solve scope
@@ -248,7 +255,7 @@ public:
         return false;
     }
 
-    bool set_constant(
+    bool constant(
             const std::string& name,
             const DynamicData& value)
     {
@@ -269,7 +276,7 @@ public:
     }
 
     // Generic type retrieval.
-    DynamicType::Ptr get_type(
+    DynamicType::Ptr type(
             const std::string& name)
     {
         // Solve scope
@@ -283,7 +290,7 @@ public:
         // TODO
 
         // Check structs
-        if (module.first->has_struct(module.second))
+        if (module.first->has_structure(module.second))
         {
             return module.first->structs.at(module.second);
         }

--- a/include/xtypes/idl/parser.hpp
+++ b/include/xtypes/idl/parser.hpp
@@ -529,7 +529,7 @@ private:
 
         std::cout << "Found const " << type->name() << " " << identifier << " = " << expr.to_string();
 
-        outer->constant(identifier, expr);
+        outer->create_constant(identifier, expr);
     }
 
     bool get_literal_value(

--- a/include/xtypes/idl/parser.hpp
+++ b/include/xtypes/idl/parser.hpp
@@ -25,6 +25,7 @@
 #include <xtypes/StructType.hpp>
 #include <xtypes/SequenceType.hpp>
 #include <xtypes/DynamicData.hpp>
+#include <xtypes/Module.hpp>
 
 #include <xtypes/idl/grammar.hpp>
 
@@ -54,9 +55,17 @@ struct Context
 
     // Results
     bool success = false;
-    std::map<std::string, DynamicType::Ptr> structs;
-    std::map<std::string, DynamicData> constants;
-    //std::map<std::string, Modules> modules;
+    std::shared_ptr<Module> module = nullptr;
+
+    std::map<std::string, DynamicType::Ptr> get_all_types()
+    {
+        std::map<std::string, DynamicType::Ptr> result;
+        if (module != nullptr)
+        {
+            module->fill_all_types(result);
+        }
+        return result;
+    }
 
     ~Context()
     {
@@ -129,8 +138,7 @@ public:
         }
         ast = peg::AstOptimizer(true).optimize(ast);
         build_on_ast(ast);
-        root_scope_->fill_all_types(context.structs);
-        //TODO: root_scope->fill_context(context);
+        context.module = root_scope_;
         context.success = true;
         return true;
     }
@@ -171,8 +179,7 @@ public:
 
             ast = peg::AstOptimizer(true).optimize(ast);
             build_on_ast(ast);
-            root_scope_->fill_all_types(context.structs);
-            //TODO: root_scope->fill_context(context);
+            context.module = root_scope_;
             context.success = true;
             return true;
         }
@@ -245,6 +252,7 @@ private:
     bool allow_kw_ids_ = false;
     std::string preprocessor_path_ = "cpp";
     std::vector<std::string> include_paths_;
+    std::shared_ptr<Module> root_scope_;
 
     static Parser* get_instance()
     {
@@ -330,177 +338,19 @@ private:
         }
         std::string cmd = preprocessor_path_ + " " + args + idl_file;
         std::string output = exec(cmd);
-        Context context;
-        context.clear = false;
-        context.preprocess = false;
-        context.ignore_case = ignore_case_;
         return output;
     }
 
-    class SymbolScope
-    {
-    public:
-        SymbolScope(
-                std::shared_ptr<SymbolScope> outer)
-            : outer(outer)
-        {}
-
-        std::string scope()
-        {
-            if (outer != nullptr && !outer->scope().empty())
-            {
-                return outer->scope() + "::" + name;
-            }
-            return name;
-        }
-
-        bool has_symbol(
-                const std::string& ident,
-                bool extend = true) const
-        {
-            size_t n_elems = structs.count(ident); // + constants.count(ident) + members.count(ident) + types.count(ident);
-            if (n_elems > 0)
-            {
-                return true;
-            }
-            if (extend && outer != nullptr)
-            {
-                return outer->has_symbol(ident, extend);
-            }
-            return false;
-        }
-
-        DynamicType::Ptr get_type(
-                const std::string& name) const
-        {
-            // Solve scope
-            if (name.find("::") != std::string::npos) // It is an scoped name
-            {
-                if (name.find("::") == 0) // Looking for root
-                {
-                    if (outer == nullptr) // We are the root, now go down.
-                    {
-                        return get_type(name.substr(2));
-                    }
-                    else // We are not the root, go up.
-                    {
-                        return outer->get_type(name);
-                    }
-                }
-                else // not looking for root
-                {
-                    std::string inner_scope = name.substr(0, name.find("::"));
-                    if (inner.count(inner_scope) > 0) // We have a inner scope that matches.
-                    {
-                        std::string inner_name = name.substr(name.find("::") + 2);
-                        const auto& it = inner.find(inner_scope);
-                        return it->second->get_type(inner_name);
-                    }
-                }
-            }
-            // No scope, or scope resolution failed: Try in upwards
-            auto it = structs.find(name);
-            if (it != structs.end())
-            {
-                return it->second;
-            }
-            if (nullptr != outer)
-            {
-                return outer->get_type(name);
-            }
-            return DynamicType::Ptr();
-        }
-
-        std::map<std::string, DynamicType::Ptr> get_all_types() const
-        {
-            std::map<std::string, DynamicType::Ptr> result;
-            fill_all_types(result);
-            return result;
-        }
-
-        void fill_all_types(
-                std::map<std::string, DynamicType::Ptr>& map) const
-        {
-            map.insert(structs.begin(), structs.end());
-            for (const auto& pair : inner)
-            {
-                pair.second->fill_all_types(map);
-            }
-        }
-
-        DynamicData get_constant(
-                const std::string& name) const
-        {
-            auto it = constants.find(name);
-            if (it != constants.end())
-            {
-                return it->second;
-            }
-
-            if (outer != nullptr)
-            {
-                return outer->get_constant(name);
-            }
-
-            return DynamicData(primitive_type<bool>());
-        }
-
-        bool has_constant(
-                const std::string& name) const
-        {
-            auto it = constants.find(name);
-            if (it != constants.end())
-            {
-                return true;
-            }
-
-            if (outer != nullptr)
-            {
-                return outer->has_constant(name);
-            }
-
-            return false;
-        }
-
-        bool set_constant(
-                const std::string& name,
-                const DynamicData& value)
-        {
-            auto inserted = constants_types.emplace(name, value.type());
-            if (inserted.second)
-            {
-                DynamicData temp(*(inserted.first->second));
-                temp = value;
-                auto result = constants.emplace(name, temp);
-                return result.second;
-            }
-            return false;
-        }
-
-        std::map<std::string, DynamicType::Ptr> constants_types;
-        std::map<std::string, DynamicData> constants;
-        //std::map<std::string, std::shared_ptr<Module>> modules;
-        //std::map<std::string, DynamicType::Ptr> types;
-        //std::map<std::string, std::shared_ptr<StructType>> structs;
-        std::map<std::string, DynamicType::Ptr> structs;
-        //std::map<std::string, std::shared_ptr<AnnotationType>> annotations;
-        std::shared_ptr<SymbolScope> outer;
-        std::map<std::string, std::shared_ptr<SymbolScope>> inner;
-        std::string name;
-    };
-
-    std::shared_ptr<SymbolScope> root_scope_;
-
-    std::shared_ptr<SymbolScope> build_on_ast(
+    std::shared_ptr<Module> build_on_ast(
             const std::shared_ptr<peg::Ast> ast,
-            std::shared_ptr<SymbolScope> scope = nullptr)
+            std::shared_ptr<Module> scope = nullptr)
     {
         using namespace peg::udl;
         if (scope == nullptr)
         {
             if (clear_ || root_scope_ == nullptr)
             {
-                root_scope_ = std::make_shared<SymbolScope>(nullptr);
+                root_scope_ = std::make_shared<Module>();
             }
             scope = root_scope_;
         }
@@ -551,7 +401,7 @@ private:
     std::string resolve_identifier(
             const std::shared_ptr<peg::Ast> ast,
             const std::string& identifier,
-            std::shared_ptr<SymbolScope> scope,
+            std::shared_ptr<Module> scope,
             bool ignore_already_used = false)
     {
         if (identifier.find("_") == 0)
@@ -607,27 +457,26 @@ private:
 
     void module_dcl(
             const std::shared_ptr<peg::Ast> ast,
-            std::shared_ptr<SymbolScope> outer)
+            std::shared_ptr<Module> outer)
     {
         using namespace peg::udl;
-        std::shared_ptr<SymbolScope> scope;
+        std::shared_ptr<Module> scope;
         for (auto& node : ast->nodes)
         {
             switch (node->tag){
                 case "IDENTIFIER"_:
                 {
                     std::string name = resolve_identifier(node, node->token, outer, true);
-                    if (outer->inner.count(name) == 0)
+                    if (!outer->has_submodule(name))
                     {
                         // New scope
-                        scope = std::make_shared<SymbolScope>(outer);
-                        scope->name = name;
-                        outer->inner.emplace(name, scope);
+                        outer->create_submodule(name);
+                        scope = outer->get_submodule(name);
                     }
                     else
                     {
                         // Adding to an already defined scope
-                        scope = outer->inner[name];
+                        scope = outer->get_submodule(name);
                     }
                     break;
                 }
@@ -640,7 +489,7 @@ private:
 
     void alias_dcl(
             const std::shared_ptr<peg::Ast> ast,
-            std::shared_ptr<SymbolScope> outer)
+            std::shared_ptr<Module> outer)
     {
         using namespace peg::udl;
 
@@ -669,7 +518,7 @@ private:
 
     void const_dcl(
             const std::shared_ptr<peg::Ast> ast,
-            std::shared_ptr<SymbolScope> outer)
+            std::shared_ptr<Module> outer)
     {
         using namespace peg::udl;
 
@@ -906,7 +755,7 @@ private:
     DynamicData solve_expr(
             const DynamicType& type,
             const std::shared_ptr<peg::Ast> ast,
-            std::shared_ptr<SymbolScope> outer) const
+            std::shared_ptr<Module> outer) const
     {
         using namespace peg::udl;
         DynamicData result(type);
@@ -1026,7 +875,7 @@ private:
 
     void enum_dcl(
             const std::shared_ptr<peg::Ast> ast,
-            std::shared_ptr<SymbolScope> outer)
+            std::shared_ptr<Module> outer)
     {
         using namespace peg::udl;
 
@@ -1038,38 +887,38 @@ private:
 
     void struct_fw_dcl(
             const std::shared_ptr<peg::Ast> ast,
-            std::shared_ptr<SymbolScope> outer)
+            std::shared_ptr<Module> outer)
     {
         using namespace peg::udl;
-        DynamicType::Ptr exists = outer->get_type(resolve_identifier(ast, ast->token, outer));
-        if (exists.get() != nullptr)
+        std::string name = resolve_identifier(ast, ast->token, outer);
+        if (outer->has_symbol(name, false))
         {
             throw exception("Struct " + ast->token + " was already declared.", ast);
         }
 
-        StructType result(ast->token);
-        outer->structs.emplace(ast->token, std::move(result));
+        StructType result(name);
+        outer->set_struct(std::move(result));
     }
 
     void union_fw_dcl(
             const std::shared_ptr<peg::Ast> ast,
-            std::shared_ptr<SymbolScope> outer)
+            std::shared_ptr<Module> outer)
     {
         using namespace peg::udl;
-        DynamicType::Ptr exists = outer->get_type(resolve_identifier(ast, ast->token, outer));
-        if (exists.get() != nullptr)
+        std::string name = resolve_identifier(ast, ast->token, outer);
+        if (outer->has_symbol(name, false))
         {
             throw exception("Union " + ast->token + " was already declared.", ast);
         }
 
         // TODO Replace by Unions. Kept as Struct to allow name solving.
-        StructType result(ast->token);
-        outer->structs.emplace(ast->token, std::move(result));
+        StructType result(name);
+        outer->set_struct(std::move(result));
     }
 
     void struct_def(
             const std::shared_ptr<peg::Ast> ast,
-            std::shared_ptr<SymbolScope> outer)
+            std::shared_ptr<Module> outer)
     {
         using namespace peg::udl;
         std::string name;
@@ -1082,7 +931,7 @@ private:
                 {
                     name = resolve_identifier(ast, node->token, outer, true);
                     StructType result(name);
-                    outer->structs.emplace(name, std::move(result));
+                    outer->set_struct(std::move(result));
                     break;
                 }
                 case "INHERITANCE"_:
@@ -1094,23 +943,22 @@ private:
             }
         }
 
-        DynamicType::Ptr result = outer->get_type(name);
-        StructType* struct_type = static_cast<StructType*>(const_cast<DynamicType*>(result.get()));
-        if (!struct_type->members().empty())
+        StructType& struct_type = outer->get_struct(name);
+        if (!struct_type.members().empty())
         {
             throw exception("Struct " + name + " redefinition.", ast);
         }
         for (auto& member : member_list)
         {
-            struct_type->add_member(std::move(member.second));
+            struct_type.add_member(std::move(member.second));
         }
         // Replace
-        outer->structs[name] = DynamicType::Ptr(*struct_type);
+        // outer->set_struct(struct_type, true);
     }
 
     void union_def(
             const std::shared_ptr<peg::Ast> ast,
-            std::shared_ptr<SymbolScope> outer)
+            std::shared_ptr<Module> outer)
     {
         using namespace peg::udl;
         std::string name;
@@ -1159,24 +1007,22 @@ private:
         std::cout << "Found \"union " << name << "\" with discriminator of type " << type->name()
                   << " but unions aren't supported. Ignoring." << std::endl;
         /* TODO
-        DynamicType::Ptr result = outer->get_type(name);
-        UnionType* union_type = static_cast<UnionType*>(const_cast<DynamicType*>(result.get()));
-        if (!union_type->members().empty())
+        UnionType& union_type = outer->get_union(name);
+        if (!union_type.members().empty())
         {
             throw exception("Union " + name + " redefinition.", ast);
         }
         for (auto& member : member_list)
         {
-            union_type->add_member(std::move(member.second));
+            union_type.add_member(std::move(member.second));
         }
-        // Replace
-        outer->unions[name] = DynamicType::Ptr(*union_type);
+        // Replace? Probably not needed.
         */
     }
 
     void annotation_dcl(
             const std::shared_ptr<peg::Ast> ast,
-            std::shared_ptr<SymbolScope> outer)
+            std::shared_ptr<Module> outer)
     {
         using namespace peg::udl;
         std::string name;
@@ -1212,13 +1058,13 @@ private:
             annotation_type.add_member(std::move(member.second));
         }
         // Replace
-        outer->annotations.emplace(name, annotation_type));
+        outer->set_annotation(annotation_type));
         */
     }
 
     void bitset_dcl(
             const std::shared_ptr<peg::Ast> ast,
-            std::shared_ptr<SymbolScope> outer)
+            std::shared_ptr<Module> outer)
     {
         using namespace peg::udl;
         std::string name;
@@ -1258,14 +1104,14 @@ private:
         {
             bitset_type.add_member(std::move(member.second));
         }
-        // Replace
-        outer->bitsets[name] = DynamicType::Ptr(bitset_type);
+        // Replace ?
+        outer->set_bitset(bitset_type);
         */
     }
 
     void bitmask_dcl(
             const std::shared_ptr<peg::Ast> ast,
-            std::shared_ptr<SymbolScope> outer)
+            std::shared_ptr<Module> outer)
     {
         using namespace peg::udl;
         std::string name;
@@ -1302,13 +1148,13 @@ private:
             bitmask_type.add_member(std::move(member.second));
         }
         // Replace
-        outer->bitmasks[name] = DynamicType::Ptr(bitmask_type);
+        outer->set_bitmask(bitmask_type);
         */
     }
 
     void member_def(
             const std::shared_ptr<peg::Ast> ast,
-            std::shared_ptr<SymbolScope> outer,
+            std::shared_ptr<Module> outer,
             std::map<std::string, Member>& result)
     {
         using namespace peg::udl;
@@ -1333,7 +1179,7 @@ private:
 
     DynamicType::Ptr type_spec(
             const std::shared_ptr<peg::Ast> node, //ast,
-            std::shared_ptr<SymbolScope> outer)
+            std::shared_ptr<Module> outer)
     {
         using namespace peg::udl;
         switch (node->tag)
@@ -1399,7 +1245,6 @@ private:
                 size_t size = 0;
                 if (node->nodes.size() > 1)
                 {
-                    //size = std::atoi(node->nodes[1]->token.c_str());
                     size = get_dimension(outer, node->nodes[1]);
                 }
                 return SequenceType(*inner_type, size);
@@ -1411,7 +1256,6 @@ private:
                 size_t size = 0;
                 if (node->nodes.size() > 2)
                 {
-                    //size = std::atoi(node->nodes[2]->token.c_str());
                     size = get_dimension(outer, node->nodes[1]);
                 }
                 std::cout << "Found \"map<" << key_type->name() << ", " << inner_type->name()
@@ -1429,7 +1273,7 @@ private:
 
     size_t get_dimension(
             const std::string& value,
-            std::shared_ptr<SymbolScope> outer,
+            std::shared_ptr<Module> outer,
             const std::shared_ptr<peg::Ast> node)
     {
         DynamicData c_data = outer->get_constant(value);
@@ -1467,7 +1311,7 @@ private:
     }
 
     size_t get_dimension(
-            std::shared_ptr<SymbolScope> outer,
+            std::shared_ptr<Module> outer,
             const std::shared_ptr<peg::Ast> node)
     {
         using namespace peg::udl;
@@ -1515,7 +1359,7 @@ private:
 
     void members(
             const std::shared_ptr<peg::Ast> ast,
-            std::shared_ptr<SymbolScope> outer,
+            std::shared_ptr<Module> outer,
             const DynamicType::Ptr type,
             std::map<std::string, Member>& result)
     {
@@ -1545,7 +1389,7 @@ private:
 
     std::vector<std::pair<std::string, std::vector<size_t>>> identifier_list(
             const std::shared_ptr<peg::Ast> node,
-            std::shared_ptr<SymbolScope> outer)
+            std::shared_ptr<Module> outer)
     {
         using namespace peg::udl;
         std::vector<std::pair<std::string, std::vector<size_t>>> result;
@@ -1568,7 +1412,7 @@ private:
 
     void identifier(
             const std::shared_ptr<peg::Ast> node,
-            std::shared_ptr<SymbolScope> outer,
+            std::shared_ptr<Module> outer,
             std::vector<std::pair<std::string, std::vector<size_t>>>& list)
     {
         using namespace peg::udl;

--- a/include/xtypes/idl/parser.hpp
+++ b/include/xtypes/idl/parser.hpp
@@ -471,12 +471,12 @@ private:
                     {
                         // New scope
                         outer->create_submodule(name);
-                        scope = outer->get_submodule(name);
+                        scope = outer->submodule(name);
                     }
                     else
                     {
                         // Adding to an already defined scope
-                        scope = outer->get_submodule(name);
+                        scope = outer->submodule(name);
                     }
                     break;
                 }
@@ -529,7 +529,7 @@ private:
 
         std::cout << "Found const " << type->name() << " " << identifier << " = " << expr.to_string();
 
-        outer->set_constant(identifier, expr);
+        outer->constant(identifier, expr);
     }
 
     bool get_literal_value(
@@ -776,7 +776,7 @@ private:
                 break;
             }
             case "SCOPED_NAME"_:
-                result = outer->get_constant(ast->token);
+                result = outer->constant(ast->token);
                 break;
             case "UNARY_EXPR"_:
                 {
@@ -897,7 +897,7 @@ private:
         }
 
         StructType result(name);
-        outer->set_struct(std::move(result));
+        outer->structure(std::move(result));
     }
 
     void union_fw_dcl(
@@ -913,7 +913,7 @@ private:
 
         // TODO Replace by Unions. Kept as Struct to allow name solving.
         StructType result(name);
-        outer->set_struct(std::move(result));
+        outer->structure(std::move(result));
     }
 
     void struct_def(
@@ -931,7 +931,7 @@ private:
                 {
                     name = resolve_identifier(ast, node->token, outer, true);
                     StructType result(name);
-                    outer->set_struct(std::move(result));
+                    outer->structure(std::move(result));
                     break;
                 }
                 case "INHERITANCE"_:
@@ -943,7 +943,7 @@ private:
             }
         }
 
-        StructType& struct_type = outer->get_struct(name);
+        StructType& struct_type = outer->structure(name);
         if (!struct_type.members().empty())
         {
             throw exception("Struct " + name + " redefinition.", ast);
@@ -952,8 +952,6 @@ private:
         {
             struct_type.add_member(std::move(member.second));
         }
-        // Replace
-        // outer->set_struct(struct_type, true);
     }
 
     void union_def(
@@ -1187,7 +1185,7 @@ private:
             case "SCOPED_NAME"_: // Scoped name
             case "IDENTIFIER"_:
             {
-                DynamicType::Ptr type = outer->get_type(node->token);
+                DynamicType::Ptr type = outer->type(node->token);
                 if (type.get() == nullptr)
                 {
                     throw exception("Member type " + node->token + " is unknown", node);
@@ -1276,7 +1274,7 @@ private:
             std::shared_ptr<Module> outer,
             const std::shared_ptr<peg::Ast> node)
     {
-        DynamicData c_data = outer->get_constant(value);
+        DynamicData c_data = outer->constant(value);
         size_t dim = 0;
         switch (c_data.type().kind())
         {
@@ -1441,7 +1439,7 @@ private:
                         }
                         case "SCOPED_NAME"_:
                         {
-                            DynamicData c_data = outer->get_constant(subnode->token);
+                            DynamicData c_data = outer->constant(subnode->token);
                             size_t dim = 0;
                             switch (c_data.type().kind())
                             {

--- a/test/unitary/main.cpp
+++ b/test/unitary/main.cpp
@@ -1412,6 +1412,9 @@ TEST (Utilities, Modules)
     DynamicData my_data(my_struct);
     my_data["outer_float"] = 5.678f;
     ASSERT_EQ(my_data["outer_float"].value<float>(), 5.678f);
+
+    const StructType& same_struct = root["A"]["A"].get_struct("OuterType"); // ::A::A::OuterType
+    ASSERT_EQ(&my_struct, &same_struct); // Both access ways must be equivalent.
 }
 
 int main(int argc, char** argv)

--- a/test/unitary/main.cpp
+++ b/test/unitary/main.cpp
@@ -1348,72 +1348,72 @@ TEST (Utilities, Modules)
     Module& submod_A = root.create_submodule("A");
     Module& submod_B = root.create_submodule("B");
     Module& submod_AA = submod_A.create_submodule("A");
-    root.set_struct(inner);
-    submod_AA.set_struct(outer);
-    submod_B.set_struct(b);
+    root.structure(inner);
+    submod_AA.structure(outer);
+    submod_B.structure(b);
 
     // (root) - A - A - OuterType
     //        \ B - BType
     //        \ InnerType
 
     // Check scopes from ROOT
-    ASSERT_TRUE(root.has_struct("A::A::OuterType"));
-    ASSERT_TRUE(root.has_struct("::A::A::OuterType"));
-    ASSERT_FALSE(root.has_struct("::A::OuterType"));
-    ASSERT_FALSE(root.has_struct("A::OuterType"));
-    ASSERT_TRUE(root.has_struct("::InnerType"));
-    ASSERT_TRUE(root.has_struct("InnerType"));
-    ASSERT_FALSE(root.has_struct("OuterType"));
-    ASSERT_FALSE(root.has_struct("BType"));
-    ASSERT_TRUE(root.has_struct("B::BType"));
-    ASSERT_TRUE(root.has_struct("::B::BType"));
-    ASSERT_FALSE(root.has_struct("A::B::BType"));
-    ASSERT_FALSE(root.has_struct("::A::B::BType"));
-    ASSERT_FALSE(root.has_struct("::B::B::BType"));
+    ASSERT_TRUE(root.has_structure("A::A::OuterType"));
+    ASSERT_TRUE(root.has_structure("::A::A::OuterType"));
+    ASSERT_FALSE(root.has_structure("::A::OuterType"));
+    ASSERT_FALSE(root.has_structure("A::OuterType"));
+    ASSERT_TRUE(root.has_structure("::InnerType"));
+    ASSERT_TRUE(root.has_structure("InnerType"));
+    ASSERT_FALSE(root.has_structure("OuterType"));
+    ASSERT_FALSE(root.has_structure("BType"));
+    ASSERT_TRUE(root.has_structure("B::BType"));
+    ASSERT_TRUE(root.has_structure("::B::BType"));
+    ASSERT_FALSE(root.has_structure("A::B::BType"));
+    ASSERT_FALSE(root.has_structure("::A::B::BType"));
+    ASSERT_FALSE(root.has_structure("::B::B::BType"));
 
     // Check scopes from A
-    ASSERT_TRUE(submod_A.has_struct("::A::A::OuterType"));
-    ASSERT_FALSE(submod_A.has_struct("A::A::OuterType"));
-    ASSERT_TRUE(submod_A.has_struct("A::OuterType"));
-    ASSERT_FALSE(submod_A.has_struct("OuterType"));
-    ASSERT_TRUE(submod_A.has_struct("::InnerType"));
-    ASSERT_FALSE(submod_A.has_struct("InnerType"));
-    ASSERT_FALSE(submod_A.has_struct("BType"));
-    ASSERT_TRUE(submod_A.has_struct("B::BType"));
-    ASSERT_FALSE(submod_A.has_struct("A::BType"));
-    ASSERT_TRUE(submod_A.has_struct("::B::BType"));
+    ASSERT_TRUE(submod_A.has_structure("::A::A::OuterType"));
+    ASSERT_FALSE(submod_A.has_structure("A::A::OuterType"));
+    ASSERT_TRUE(submod_A.has_structure("A::OuterType"));
+    ASSERT_FALSE(submod_A.has_structure("OuterType"));
+    ASSERT_TRUE(submod_A.has_structure("::InnerType"));
+    ASSERT_FALSE(submod_A.has_structure("InnerType"));
+    ASSERT_FALSE(submod_A.has_structure("BType"));
+    ASSERT_TRUE(submod_A.has_structure("B::BType"));
+    ASSERT_FALSE(submod_A.has_structure("A::BType"));
+    ASSERT_TRUE(submod_A.has_structure("::B::BType"));
 
     // Check scopes from A::A
-    ASSERT_TRUE(submod_AA.has_struct("::A::A::OuterType"));
-    ASSERT_FALSE(submod_AA.has_struct("A::A::OuterType"));
-    ASSERT_TRUE(submod_AA.has_struct("A::OuterType"));
-    ASSERT_TRUE(submod_AA.has_struct("OuterType"));
-    ASSERT_TRUE(submod_AA.has_struct("::InnerType"));
-    ASSERT_FALSE(submod_AA.has_struct("InnerType"));
-    ASSERT_FALSE(submod_AA.has_struct("BType"));
-    ASSERT_TRUE(submod_AA.has_struct("B::BType"));
-    ASSERT_FALSE(submod_AA.has_struct("A::BType"));
-    ASSERT_TRUE(submod_AA.has_struct("::B::BType"));
+    ASSERT_TRUE(submod_AA.has_structure("::A::A::OuterType"));
+    ASSERT_FALSE(submod_AA.has_structure("A::A::OuterType"));
+    ASSERT_TRUE(submod_AA.has_structure("A::OuterType"));
+    ASSERT_TRUE(submod_AA.has_structure("OuterType"));
+    ASSERT_TRUE(submod_AA.has_structure("::InnerType"));
+    ASSERT_FALSE(submod_AA.has_structure("InnerType"));
+    ASSERT_FALSE(submod_AA.has_structure("BType"));
+    ASSERT_TRUE(submod_AA.has_structure("B::BType"));
+    ASSERT_FALSE(submod_AA.has_structure("A::BType"));
+    ASSERT_TRUE(submod_AA.has_structure("::B::BType"));
 
     // Check scopes from B
-    ASSERT_TRUE(submod_B.has_struct("::A::A::OuterType"));
-    ASSERT_TRUE(submod_B.has_struct("A::A::OuterType"));
-    ASSERT_FALSE(submod_B.has_struct("A::OuterType"));
-    ASSERT_FALSE(submod_B.has_struct("OuterType"));
-    ASSERT_TRUE(submod_B.has_struct("::InnerType"));
-    ASSERT_FALSE(submod_B.has_struct("InnerType"));
-    ASSERT_TRUE(submod_B.has_struct("BType"));
-    ASSERT_TRUE(submod_B.has_struct("B::BType"));
-    ASSERT_FALSE(submod_B.has_struct("A::BType"));
-    ASSERT_TRUE(submod_B.has_struct("::B::BType"));
+    ASSERT_TRUE(submod_B.has_structure("::A::A::OuterType"));
+    ASSERT_TRUE(submod_B.has_structure("A::A::OuterType"));
+    ASSERT_FALSE(submod_B.has_structure("A::OuterType"));
+    ASSERT_FALSE(submod_B.has_structure("OuterType"));
+    ASSERT_TRUE(submod_B.has_structure("::InnerType"));
+    ASSERT_FALSE(submod_B.has_structure("InnerType"));
+    ASSERT_TRUE(submod_B.has_structure("BType"));
+    ASSERT_TRUE(submod_B.has_structure("B::BType"));
+    ASSERT_FALSE(submod_B.has_structure("A::BType"));
+    ASSERT_TRUE(submod_B.has_structure("::B::BType"));
 
     // Check accesibility and DynamicData creation.
-    const StructType& my_struct = root.get_struct("A::A::OuterType");
+    const StructType& my_struct = root.structure("A::A::OuterType");
     DynamicData my_data(my_struct);
     my_data["outer_float"] = 5.678f;
     ASSERT_EQ(my_data["outer_float"].value<float>(), 5.678f);
 
-    const StructType& same_struct = root["A"]["A"].get_struct("OuterType"); // ::A::A::OuterType
+    const StructType& same_struct = root["A"]["A"].structure("OuterType"); // ::A::A::OuterType
     ASSERT_EQ(&my_struct, &same_struct); // Both access ways must be equivalent.
 }
 

--- a/test/unitary/parser_test.cpp
+++ b/test/unitary/parser_test.cpp
@@ -44,7 +44,7 @@ TEST (IDLParser, simple_struct_test)
             wstring my_wstring;
         };
                    )");
-    std::map<std::string, DynamicType::Ptr>& result = context.structs;
+    std::map<std::string, DynamicType::Ptr> result = context.module->get_all_types();
     EXPECT_EQ(1, result.size());
 
     const DynamicType* my_struct = result["SimpleStruct"].get();
@@ -99,7 +99,7 @@ TEST (IDLParser, array_sequence_struct_test)
             sequence<char, 6> my_char6_seq;
         };
                    )");
-    std::map<std::string, DynamicType::Ptr>& result = context.structs;
+    std::map<std::string, DynamicType::Ptr> result = context.module->get_all_types();
     EXPECT_EQ(1, result.size());
 
     const DynamicType* my_struct = result["SimpleStruct"].get();
@@ -201,7 +201,7 @@ TEST (IDLParser, inner_struct_test)
             RecursiveStruct rec;
         };
                    )");
-    std::map<std::string, DynamicType::Ptr>& result = context.structs;
+    std::map<std::string, DynamicType::Ptr> result = context.module->get_all_types();
     EXPECT_EQ(3, result.size());
 
     const DynamicType* my_struct = result["SuperStruct"].get();
@@ -220,7 +220,7 @@ TEST (IDLParser, multiple_declarator_members_test)
             boolean my_bool_5[5], other[55], another, multi_array[2][3];
         };
                    )");
-    std::map<std::string, DynamicType::Ptr>& result = context.structs;
+    std::map<std::string, DynamicType::Ptr> result = context.module->get_all_types();
     EXPECT_EQ(1, result.size());
 }
 
@@ -264,7 +264,7 @@ TEST (IDLParser, name_collision)
                        )",
                        context
             );
-        std::map<std::string, DynamicType::Ptr>& result = context.structs;
+        std::map<std::string, DynamicType::Ptr> result = context.module->get_all_types();
         EXPECT_EQ(1, result.size());
     }
 
@@ -294,7 +294,7 @@ TEST (IDLParser, name_collision)
             };
                        )"
             );
-        std::map<std::string, DynamicType::Ptr>& result = context.structs;
+        std::map<std::string, DynamicType::Ptr> result = context.module->get_all_types();
         EXPECT_EQ(1, result.size());
 
         const DynamicType* my_struct = result["MyStruct"].get();
@@ -429,7 +429,7 @@ TEST (IDLParser, module_scope_test)
         };
                    )");
 
-    std::map<std::string, DynamicType::Ptr>& result = context.structs;
+    std::map<std::string, DynamicType::Ptr> result = context.module->get_all_types();
     EXPECT_EQ(5, result.size());
 }
 
@@ -537,7 +537,7 @@ TEST (IDLParser, constants)
             };
                        )");
 
-        std::map<std::string, DynamicType::Ptr>& result = context.structs;
+        std::map<std::string, DynamicType::Ptr> result = context.module->get_all_types();
         EXPECT_EQ(1, result.size());
 
         const DynamicType* my_struct = result["MyStruct"].get();
@@ -649,7 +649,7 @@ TEST (IDLParser, const_value_parser)
             };
                        )");
 
-        std::map<std::string, DynamicType::Ptr>& result = context.structs;
+        std::map<std::string, DynamicType::Ptr> result = context.module->get_all_types();
         EXPECT_EQ(1, result.size());
 
         const DynamicType* my_struct = result["MyStruct"].get();
@@ -663,7 +663,7 @@ TEST (IDLParser, const_value_parser)
 TEST (IDLParser, parse_file)
 {
     Context context = parse_file("idl/test01.idl");
-    std::map<std::string, DynamicType::Ptr>& result = context.structs;
+    std::map<std::string, DynamicType::Ptr> result = context.module->get_all_types();
     EXPECT_EQ(1, result.size());
     const DynamicType* my_struct = result["Test01"].get();
     DynamicData data(*my_struct);
@@ -685,7 +685,7 @@ TEST (IDLParser, include_from_string)
             };
         };
         )");
-    std::map<std::string, DynamicType::Ptr>& result = context.structs;
+    std::map<std::string, DynamicType::Ptr> result = context.module->get_all_types();
     EXPECT_EQ(2, result.size());
     const DynamicType* my_struct = result["Test00"].get();
     DynamicData data(*my_struct);
@@ -697,7 +697,7 @@ TEST (IDLParser, include_from_file_02_local)
     Context context;
     context.include_paths.push_back("idl");
     parse_file("idl/test02.idl", context);
-    std::map<std::string, DynamicType::Ptr>& result = context.structs;
+    std::map<std::string, DynamicType::Ptr> result = context.module->get_all_types();
     EXPECT_EQ(2, result.size());
     const DynamicType* my_struct = result["Test02"].get();
     DynamicData data(*my_struct);
@@ -709,7 +709,7 @@ TEST (IDLParser, include_from_file_03_global)
     Context context;
     context.include_paths.push_back("idl/include");
     parse_file("idl/test03.idl", context);
-    std::map<std::string, DynamicType::Ptr>& result = context.structs;
+    std::map<std::string, DynamicType::Ptr> result = context.module->get_all_types();
     EXPECT_EQ(2, result.size());
     const DynamicType* my_struct = result["Test03"].get();
     DynamicData data(*my_struct);
@@ -722,7 +722,7 @@ TEST (IDLParser, include_from_file_04_multi)
     context.include_paths.push_back("idl");
     context.include_paths.push_back("idl/include");
     parse_file("idl/test04.idl", context);
-    std::map<std::string, DynamicType::Ptr>& result = context.structs;
+    std::map<std::string, DynamicType::Ptr> result = context.module->get_all_types();
     EXPECT_EQ(3, result.size());
     const DynamicType* my_struct = result["Test04"].get();
     DynamicData data(*my_struct);

--- a/test/unitary/parser_test.cpp
+++ b/test/unitary/parser_test.cpp
@@ -280,7 +280,7 @@ TEST (IDLParser, name_collision)
                        )",
                        context
             );
-        std::map<std::string, DynamicType::Ptr>& result = context.structs;
+        std::map<std::string, DynamicType::Ptr> result = context.module->get_all_types();
         EXPECT_EQ(1, result.size());
     }
 


### PR DESCRIPTION
This PR adds the module's features.

- Added Module class, that allows the user to organize its types and constants in a similar way as using namespaces.
- Parser's context now contains a `module` member that contains the root module of the IDL parser. A method `get_all_types` has been added to ease the retrieval of all the defined types.