### PR TITLE
Fix Module::has_symbol method for aliases

### DIFF
--- a/include/xtypes/Module.hpp
+++ b/include/xtypes/Module.hpp
@@ -108,6 +108,7 @@ public:
             bool extend = true) const
     {
         bool has_it = structs_.count(ident) > 0
+            || aliases_.count(ident) > 0
             || constants_.count(ident) > 0
             || enumerations_32_.count(ident) > 0
             || inner_.count(ident) > 0;


### PR DESCRIPTION
I believe this `||` operand for `aliases_` list was missing since the introduction of `has_it` boolean flag.