### PR TITLE
Refs #6661 Multidimensional array constructor [7304]

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,10 +166,10 @@ int array[2][3];
 ```
 Using ArrayType, the same can be achieved just creating an array, and then using it as the content of the outer array:
 ```c++
-ArrayType array(ArrayType(primitive_type<int32_T>(), 3), 2); // Conceptually equivalent to "int array[2][3];"
+ArrayType array(ArrayType(primitive_type<int32_t>(), 3), 2); // Conceptually equivalent to "int array[2][3];"
 ```
 Note that the dimensions are swapped, because the inner array is the *second* index.
-To ease this kind of type, ArrayType provides a constructor that receives an `std::vector` of dimensions (`uint32_t`).
+To ease this kind of type definition, ArrayType provides a constructor that receives an `std::vector` of dimensions (`uint32_t`).
 This constructor receives the indexes in the natural order, like in the *C-like* example:
 ```c++
 ArrayType array(primitive_type<int32_t>, {2, 3});

--- a/README.md
+++ b/README.md
@@ -159,6 +159,22 @@ size_t str1_bounds = str1.bounds(); // As str1 is an unbounded string, its bound
 size_t str2_bounds = str2.bounds(); // As str2 is a bounded string, its bounds are 50.
 ```
 
+##### Multidimensional ArrayType
+In a *C-like* language, the programmer can define multidimensional arrays as an array of array. For example:
+```c++
+int array[2][3];
+```
+Using ArrayType, the same can be achieved just creating an array, and then using it as the content of the outer array:
+```c++
+ArrayType array(ArrayType(primitive_type<int32_T>(), 3), 2); // Conceptually equivalent to "int array[2][3];"
+```
+Note that the dimensions are swapped, because the inner array is the *second* index.
+To ease this kind of type, ArrayType provides a constructor that receives an `std::vector` of dimensions (`uint32_t`).
+This constructor receives the indexes in the natural order, like in the *C-like* example:
+```c++
+ArrayType array(primitive_type<int32_t>, {2, 3});
+```
+
 #### StructType
 Similarly to a *C-like struct*, a `StructType` represents an aggregation of members.
 You can specify a `StructType` given the type name of the structure.

--- a/include/xtypes/ArrayType.hpp
+++ b/include/xtypes/ArrayType.hpp
@@ -62,6 +62,30 @@ public:
     ArrayType(const ArrayType& other) = default;
     ArrayType(ArrayType&& other) = default;
 
+    /// \brief Direct multidimensional ArrayType constructor
+    /// Allows to create multidimensional ArrayTypes without explicitly create internal sub-arrays. For example:
+    /// Without using this constructor: ArrayType(ArrayType(ArrayType(primitive_type<float>(), 3), 2), 1);
+    /// Using this constructor: ArrayType(primitive_type<float>(), {1, 2, 3});
+    ArrayType(
+            const DynamicType& content,
+            const std::vector<uint32_t>& dimensions)
+    {
+        xtypes_assert(!dimensions.empty(), "Cannot create an ArrayType without dimensions.");
+        kind_ = TypeKind::ARRAY_TYPE;
+        dimension_ = dimensions.at(0);
+        if (dimensions.size() > 1)
+        {
+            std::vector<uint32_t> content_dims(dimensions.size() - 1);
+            std::copy(dimensions.begin() + 1, dimensions.end(), content_dims.begin());
+            content_ = DynamicType::Ptr(ArrayType(content, content_dims));
+        }
+        else
+        {
+            content_ = DynamicType::Ptr(content);
+        }
+        name_ = "array_" + std::to_string(dimension_) + "_" + content.name();
+    }
+
     /// \brief Dimension of the array.
     /// \returns The dimension.
     uint32_t dimension() const { return dimension_; }

--- a/include/xtypes/CollectionType.hpp
+++ b/include/xtypes/CollectionType.hpp
@@ -46,6 +46,8 @@ public:
     virtual size_t get_instance_size(const uint8_t* instance) const = 0;
 
 protected:
+    CollectionType() : DynamicType (TypeKind::COLLECTION_TYPE, "") {} // Empty constructor for Array's multidim ctor.
+
     CollectionType(
             TypeKind kind,
             const std::string& name,
@@ -54,7 +56,6 @@ protected:
         , content_(std::move(content))
     {}
 
-private:
     DynamicType::Ptr content_;
 };
 

--- a/include/xtypes/DynamicType.hpp
+++ b/include/xtypes/DynamicType.hpp
@@ -173,7 +173,6 @@ protected:
     /// \returns a new DynamicType without managing.
     virtual DynamicType* clone() const = 0;
 
-private:
     TypeKind kind_;
     std::string name_;
 

--- a/test/unitary/xtypes/collection_types.cpp
+++ b/test/unitary/xtypes/collection_types.cpp
@@ -96,6 +96,37 @@ TEST (CollectionTypes, multi_array)
 
 }
 
+TEST (CollectionTypes, multi_array_constructor)
+{
+
+    ArrayType array_array_array(primitive_type<uint32_t>(), {3, 4, 5});
+
+    EXPECT_EQ(array_array_array.dimension(), 3);
+
+    EXPECT_EQ(array_array_array.memory_size(), 3 * 4 * 5 * sizeof(uint32_t));
+
+    DynamicData data(array_array_array);
+
+    EXPECT_EQ(data.bounds(), 3);
+
+    for (size_t i = 0; i < 3; ++i)
+    {
+        EXPECT_EQ(data[i].bounds(), 4);
+        for (size_t j = 0; j < 4; ++j)
+        {
+            EXPECT_EQ(data[i][j].bounds(), 5);
+            for (size_t k = 0; k < 5; ++k)
+            {
+                data[i][j][k] = static_cast<uint32_t>(i + j + k);
+                uint32_t temp = data[i][j][k];
+                EXPECT_EQ(data[i][j][k].value<uint32_t>(), static_cast<uint32_t>(i + j + k));
+                EXPECT_EQ(temp, static_cast<uint32_t>(i + j + k));
+            }
+        }
+    }
+
+}
+
 template<typename T>
 void check_primitive_array(T value)
 {

--- a/test/unitary/xtypes/collection_types.cpp
+++ b/test/unitary/xtypes/collection_types.cpp
@@ -100,8 +100,12 @@ TEST (CollectionTypes, multi_array_constructor)
 {
 
     ArrayType array_array_array(primitive_type<uint32_t>(), {3, 4, 5});
+    const ArrayType& inner = static_cast<const ArrayType&>(array_array_array.content_type());
+    const ArrayType& inner_inner = static_cast<const ArrayType&>(inner.content_type());
 
     EXPECT_EQ(array_array_array.dimension(), 3);
+    EXPECT_EQ(inner.dimension(), 4);
+    EXPECT_EQ(inner_inner.dimension(), 5);
 
     EXPECT_EQ(array_array_array.memory_size(), 3 * 4 * 5 * sizeof(uint32_t));
 

--- a/test/unitary/xtypes/collection_types.cpp
+++ b/test/unitary/xtypes/collection_types.cpp
@@ -122,9 +122,19 @@ TEST (CollectionTypes, multi_array_constructor)
             for (size_t k = 0; k < 5; ++k)
             {
                 data[i][j][k] = static_cast<uint32_t>(i + j + k);
-                uint32_t temp = data[i][j][k];
+            }
+        }
+    }
+
+    for (size_t i = 0; i < 3; ++i)
+    {
+        EXPECT_EQ(data[i].bounds(), 4);
+        for (size_t j = 0; j < 4; ++j)
+        {
+            EXPECT_EQ(data[i][j].bounds(), 5);
+            for (size_t k = 0; k < 5; ++k)
+            {
                 EXPECT_EQ(data[i][j][k].value<uint32_t>(), static_cast<uint32_t>(i + j + k));
-                EXPECT_EQ(temp, static_cast<uint32_t>(i + j + k));
             }
         }
     }


### PR DESCRIPTION
This PR adds a new constructor that allows simplifying the creation of multidimensional arrays:

```c++
ArrayType(ArrayType(ArrayType(primitive_type<float>(), 3), 2), 1); // legacy way
ArrayType(primitive_type<float>(), {1, 2, 3}); // added way
``` 

This new constructor is coherent with the equivalent C++ code `float array[1][2][3];` and the IDL representation regarding the order of the dimensions.