### PR TITLE
Refs #6748 MapType [7307]

### DIFF
--- a/README.md
+++ b/README.md
@@ -508,7 +508,8 @@ If the visitor callback implementation does not call an exception, `for_each` fu
 #### Iterators of `DynamicData`
 
 There exists two kinds of iterators:
-- Collection iterators: Allows to iterate through collections in the same way of native C++11 types. They can be
+- Collection iterators: Allows to iterate through collections (`ArrayType`, `SequenceType`, and `MapType`)
+  in the same way of native C++11 types. They can be
   accessed from `ReadableDynamicDataRef::Iterator` (for read-only operations) or `WritableDynamicDataRef::Iterator`
   (for read-write operations).
   ```cpp
@@ -517,7 +518,7 @@ There exists two kinds of iterators:
   for (ReadableDynamicDataRef&& elem : data) { [...] }
   for (WritableDynamicDataRef&& elem : data) { [...] }
   ```
-  In a similar way as in the C++11 map iterator, a `PairType` instance is returned.
+  While iterating a `MapType`, similarly as in the C++11 map iterator, a `PairType` instance is returned.
   To access the elements of the pair (the map's key)
   the `operator[](size_t)` must be used. Only indexes `0` and `1` are allowed.
   ```cpp

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ The API is divided into two different and yet related conceps.
 
 ### Type definition
 All types inherit from the base abstract type `DynamicType` as shown in the following diagram:
-![](https://www.plantuml.com/plantuml/img/ZP912i8m44NtSufUe3UGqg8k1Q4LrzDqA84ahSb4A7XuBK9iGgjk_ty_-JD9wHWjUwtWRAMMBE_KJ2DbkH_pHv4T9eDQYbc2gkyjzSXoC5l8Vb2An3S2AYNHRRerMozuQIUtmiKafwS0LDRYj2JYLd3oZAsYzQu9EnUIfbyIgt6u_WlMTFDa1FqcuMYy9ejCtHAEtYamoHXn501RnnO5HziEOhh2O2IDWhvUM2XqBkwtQufFAYurM-z4CiDib6IwrwTy0W00)
+![](https://www.plantuml.com/plantuml/img/ZP912i8m44NtSufUe3SGiQXBGMZ5zJGTIY1DwsGY53oy1g4seLMtyzydRvBid22Bxmp0cNMdHT-f6WVASZ_aZsrs62rsMeKH56tBrABetguX-zuOKj-8mcXqQ-4PDQzbK0fx9VCu4OABJGvE0IYOSPmJiJ2Sl61jQ7cDX0r2shPpOh4Ert_1acwUhABVv0c7tn0ShU-8KQYPmz4xJqooQrm5mDe9evBeIQPXUizJa1XDysLXPT2vs6zJRJ-jM2f4xqQoGmXsP9lNhtu2)
 
 #### PrimitiveType
 Represents the system's basic types.

--- a/README.md
+++ b/README.md
@@ -338,7 +338,7 @@ The following methods are available when:
     data = L"Hello again! \u263A"; // set string value
     ```
 1. `DynamicData` represents a `PairType`. Similar to *C++* `std::pair`, but using `operator[](size_t)`
-    to access each member, but using 0 to access `first` and 1 to access `second`.
+    to access each member, using 0 to access `first` and 1 to access `second`.
     ```c++
     data[0] = first_value; // set "first" member value to "first_value".
     data[1] = second_value; // set "second" member value to "second_value".
@@ -390,6 +390,8 @@ The following methods are available when:
     access to the pair stored at the index position?
     These pairs are ordered internally using a hashing the key's value, so the order while iterating may change
     after any modification of the map.
+
+    **IMPORTANT: Don't modify the key value while iterating the pairs of a map, it probably makes the map unusable.**
     ```c++
     StringType key_type;
     MapType map_type(key_type, primitive_type<uint64_t>());

--- a/README.md
+++ b/README.md
@@ -165,8 +165,8 @@ size_t m2_bounds = m2.bounds(); // As m2 is a bounded map, its bounds are 10.
 ```
 
 ##### PairType
-The `MapType` is a specialization of `CollectionType` which content is a set of *pairs*.
-This *pairs* are represented internally by an auxiliar type named `PairType`.
+`MapType` is a specialization of `CollectionType` which content is a set of *pairs*.
+These *pairs* are represented internally by an auxiliar type named `PairType`.
 ```cpp
 PairType pair(StringType(), primitive_type<uint32_t>);
 std::cout << pair.first().name() << std::endl; // Prints "std::string".
@@ -337,6 +337,12 @@ The following methods are available when:
     data = "Hello again!"; // set string value
     data = L"Hello again! \u263A"; // set string value
     ```
+1. `DynamicData` represents a `PairType`. Similar to *C++* `std::pair`, but using `operator[](size_t)`
+    to access each member, but using 0 to access `first` and 1 to access `second`.
+    ```c++
+    data[0] = first_value; // set "first" member value to "first_value".
+    data[1] = second_value; // set "second" member value to "second_value".
+    ```
 1. `DynamicData` represents an `AggregationType`
     ```c++
     data["member_name"] = 42; //set value 42 to the int member called "member_name"
@@ -379,10 +385,10 @@ The following methods are available when:
 1. `DynamicData` represents a `MapType`.
     The map must be accessed by its key (using always a DynamicData instance of the key type)
     or iterated through its pairs.
-    Accesing the map using the index is forbiden because if the map's key is a numeral type, this may lead to
-    confusion to the user. For example, do the user want to access the value associated to that index value, or
+    Accessing the map using the index is forbidden because if the map's key is a numeral type, this may lead to
+    confusion to the user. For example, does the user want to access the value associated with that index value, or
     access to the pair stored at the index position?
-    This pairs are ordered internally using a hashing the key's value, so the order while iterating may change
+    These pairs are ordered internally using a hashing the key's value, so the order while iterating may change
     after any modification of the map.
     ```c++
     StringType key_type;

--- a/docs/types_inheritance.puml
+++ b/docs/types_inheritance.puml
@@ -1,9 +1,10 @@
 @startuml
+
 PrimitiveType -up-|> DynamicType
 AggregationType -up-|> DynamicType
 CollectionType -up-|> DynamicType
-
 AliasType -up-|> DynamicType
+PairType -up-|> DynamicType
 
 StructType -up-|> AggregationType
 UnionType -up-|> AggregationType
@@ -14,6 +15,7 @@ MutableCollectionType -up-|> CollectionType
 StringType -up-|> MutableCollectionType
 WStringType -up-|> MutableCollectionType
 SequenceType -up-|> MutableCollectionType
+MapType -up-|> MutableCollectionType
 
 EnumeratedType -up-|> PrimitiveType
 EnumerationType -up-|> EnumeratedType

--- a/examples/complex_type.cpp
+++ b/examples/complex_type.cpp
@@ -31,6 +31,7 @@ int main()
     outer.add_member("om9", SequenceType(SequenceType(primitive_type<uint32_t>(), 5), 3));
     outer.add_member("om10", ArrayType(ArrayType(primitive_type<uint32_t>(), 2), 3));
     outer.add_member("om11", abool);
+    outer.add_member("om12", MapType(StringType(), inner));
 
     std::cout << idl::generate(inner) << std::endl;
     std::cout << idl::generate(outer) << std::endl;
@@ -50,6 +51,13 @@ int main()
     data["om7"][1] = 123u;                                 //ArrayType(PrimitiveType<uint32_t>)
     data["om8"][1] = data["om2"];                          //ArrayType(inner)
     data["om11"] = true;                                   //AliasType(PrimitiveType<bool>))
+    StringType str_type;
+    DynamicData map_key(str_type);
+    map_key = "first";
+    data["om12"][map_key] = data["om2"];                   //MapType(StringType(), inner)
+    map_key = "second";
+    data["om12"][map_key]["im1"] = 43u;                    //...
+    data["om12"][map_key]["im2"] = 35.9f;                  //...
 
     std::cout << data.to_string() << std::endl; //See to_string() implementation as an example of data instrospection
 

--- a/include/xtypes/AliasType.hpp
+++ b/include/xtypes/AliasType.hpp
@@ -150,6 +150,12 @@ public:
         return *t;
     }
 
+    virtual uint64_t hash(
+            const uint8_t* instance) const override
+    {
+        return aliased_->hash(instance);
+    }
+
 protected:
     virtual DynamicType* clone() const override
     {

--- a/include/xtypes/ArrayType.hpp
+++ b/include/xtypes/ArrayType.hpp
@@ -257,6 +257,25 @@ public:
         return dimension_;
     }
 
+    virtual uint64_t hash(
+            const uint8_t* c_instance) const override
+    {
+        uint8_t* instance = const_cast<uint8_t*>(c_instance);
+        if (content_type().is_constructed_type())
+        {
+            uint64_t h = content_type().hash(instance);
+            for (size_t i = 1; i < dimension_; ++i)
+            {
+                Instanceable::hash_combine(h, content_type().hash(get_instance_at(instance, i)));
+            }
+            return h;
+        }
+        else
+        {
+            return Instanceable::hash(instance);
+        }
+    }
+
 protected:
     virtual DynamicType* clone() const override
     {

--- a/include/xtypes/ArrayType.hpp
+++ b/include/xtypes/ArrayType.hpp
@@ -260,20 +260,24 @@ public:
     virtual uint64_t hash(
             const uint8_t* c_instance) const override
     {
-        uint8_t* instance = const_cast<uint8_t*>(c_instance);
-        if (content_type().is_constructed_type())
+        if (dimension_ > 0)
         {
-            uint64_t h = content_type().hash(instance);
-            for (size_t i = 1; i < dimension_; ++i)
+            uint8_t* instance = const_cast<uint8_t*>(c_instance);
+            if (content_type().is_constructed_type())
             {
-                Instanceable::hash_combine(h, content_type().hash(get_instance_at(instance, i)));
+                uint64_t h = content_type().hash(instance);
+                for (size_t i = 1; i < dimension_; ++i)
+                {
+                    Instanceable::hash_combine(h, content_type().hash(get_instance_at(instance, i)));
+                }
+                return h;
             }
-            return h;
+            else
+            {
+                return Instanceable::hash(instance);
+            }
         }
-        else
-        {
-            return Instanceable::hash(instance);
-        }
+        return 0;
     }
 
 protected:

--- a/include/xtypes/DynamicData.hpp
+++ b/include/xtypes/DynamicData.hpp
@@ -773,7 +773,7 @@ public:
     /// If the key doesn't exists, creates an unitilized entry, adding the key.
     /// \returns A writable reference of the DynamicData accessed.
     WritableDynamicDataRef operator [] (
-            ReadableDynamicDataRef data) const
+            ReadableDynamicDataRef data)
     {
         xtypes_assert(
             type_.kind() == TypeKind::MAP_TYPE,
@@ -784,7 +784,7 @@ public:
         uint8_t* instance = map.get_instance_at(instance_, p_instance(data));
         if (instance == nullptr)
         {
-            uint8_t new_entry[pair.memory_size()];
+            uint8_t new_entry[pair.memory_size()] = {0};
             std::memcpy(new_entry, p_instance(data), pair.first().memory_size()); // Don't copy the "second" part.
             uint8_t* result = map.insert_instance(instance_, new_entry);
             xtypes_assert(result != nullptr, "Cannot insert new element into map.");

--- a/include/xtypes/DynamicData.hpp
+++ b/include/xtypes/DynamicData.hpp
@@ -24,6 +24,7 @@
 #include <xtypes/PrimitiveType.hpp>
 #include <xtypes/EnumerationType.hpp>
 #include <xtypes/AliasType.hpp>
+#include <xtypes/MapType.hpp>
 
 namespace eprosima {
 namespace xtypes {
@@ -150,6 +151,20 @@ public:
 
         xtypes_assert(type_.kind() != TypeKind::UNION_TYPE, "Members of UnionType cannot be accessed by index.");
 
+        if (type_.kind() == TypeKind::PAIR_TYPE)
+        {
+            xtypes_assert(index < 2, "operator[" << index << "] is out of bounds.");
+            const PairType& pair = static_cast<const PairType&>(type_);
+            if (index == 0)
+            {
+                return ReadableDynamicDataRef(pair.first(), instance_);
+            }
+            else
+            {
+                return ReadableDynamicDataRef(pair.second(), instance_ + pair.first().memory_size());
+            }
+        }
+
         const AggregationType& aggregation = static_cast<const StructType&>(type_);
         const Member& member = aggregation.member(index);
         return ReadableDynamicDataRef(member.type(), instance_ + member.offset());
@@ -164,6 +179,25 @@ public:
         const UnionType& aggregation = static_cast<const UnionType&>(type_);
         const Member& member = aggregation.member(0);
         return ReadableDynamicDataRef(member.type(), instance_);
+    }
+
+    /// \brief key access method by DynamicData.
+    /// \param[in] data DynamicData representing a MapType key.
+    /// \pre The DynamicData must represent a MapType.
+    /// |pre The key must exists.
+    /// \returns A readable reference of the DynamicData accessed.
+    ReadableDynamicDataRef at (
+            ReadableDynamicDataRef data) const
+    {
+        xtypes_assert(
+            type_.kind() == TypeKind::MAP_TYPE,
+            "operator[const DynamicData&] is only available for MapType.");
+
+        const MapType& map = static_cast<const MapType&>(type_);
+        const PairType& pair = static_cast<const PairType&>(map.content_type());
+        uint8_t* instance = map.get_instance_at(instance_, data.instance_);
+        xtypes_assert(instance != nullptr, "MapType '" << type_.name() << "' doesn't contains the requested key.");
+        return ReadableDynamicDataRef(pair.second(), instance + pair.first().memory_size());
     }
 
     /// \brief Size of the DynamicData.
@@ -506,6 +540,7 @@ protected:
         xtypes_assert(type_.is_aggregation_type(),
             "operator [const std::string&] isn't available for type '" << type_.name() << "'.");
         const AggregationType& aggregation = static_cast<const AggregationType&>(type_);
+        xtypes_assert(type_.kind() != TypeKind::PAIR_TYPE, "PairType doesn't have operator [const std::string&]");
         xtypes_assert(aggregation.has_member(member_name),
             "Type '" << type_.name() << "' doesn't have a member named '" << member_name << "'.");
 
@@ -703,7 +738,7 @@ public:
     /// \brief See ReadableDynamicDataRef::operator[]()
     /// \returns A writable reference to the DynamicData accessed.
     WritableDynamicDataRef operator [] (
-            size_t index) //
+            size_t index)
     {
         return ReadableDynamicDataRef::operator[](index);
     }
@@ -730,6 +765,76 @@ public:
         xtypes_assert(type_.kind() == TypeKind::UNION_TYPE, "discriminator is only available for UnionType.");
         UnionType& un = const_cast<UnionType&>(static_cast<const UnionType&>(type_));
         un.select_disc(disc.type(), instance_, p_instance(disc));
+    }
+
+    /// \brief index access operator by DynamicData.
+    /// \param[in] data DynamicData representing a MapType key.
+    /// \pre The DynamicData must represent a MapType.
+    /// If the key doesn't exists, creates an unitilized entry, adding the key.
+    /// \returns A writable reference of the DynamicData accessed.
+    WritableDynamicDataRef operator [] (
+            ReadableDynamicDataRef data) const
+    {
+        xtypes_assert(
+            type_.kind() == TypeKind::MAP_TYPE,
+            "operator[const DynamicData&] is only available for MapType.");
+
+        const MapType& map = static_cast<const MapType&>(type_);
+        const PairType& pair = static_cast<const PairType&>(map.content_type());
+        uint8_t* instance = map.get_instance_at(instance_, p_instance(data));
+        if (instance == nullptr)
+        {
+            uint8_t new_entry[pair.memory_size()];
+            std::memcpy(new_entry, p_instance(data), pair.first().memory_size()); // Don't copy the "second" part.
+            uint8_t* result = map.insert_instance(instance_, new_entry);
+            xtypes_assert(result != nullptr, "Cannot insert new element into map.");
+            instance = result;
+            pair.second().construct_instance(instance + pair.first().memory_size()); // "second" part initilized here!
+        }
+        return WritableDynamicDataRef(pair.second(), instance + pair.first().memory_size());
+    }
+
+    /// \brief key access method by DynamicData.
+    /// \param[in] data DynamicData representing a MapType key.
+    /// \pre The DynamicData must represent a MapType.
+    /// |pre The key must exists.
+    /// \returns A writable reference of the DynamicData accessed.
+    WritableDynamicDataRef at (
+            ReadableDynamicDataRef data)
+    {
+        return ReadableDynamicDataRef::at(data);
+    }
+
+    /// \brief inserts a pair key, value into the DynamicData.
+    /// \param[in] data DynamicData representing a PairType key.
+    /// \pre The DynamicData must represent a MapType.
+    /// If the key already exists, or the map reached its limits, returns false.
+    /// \returns If the insertion succeded.
+    bool insert (
+            ReadableDynamicDataRef data) const
+    {
+        xtypes_assert(
+            type_.kind() == TypeKind::MAP_TYPE,
+            "insert method is only available for MapType.");
+
+        const MapType& map = static_cast<const MapType&>(type_);
+        xtypes_assert(map.content_type().is_compatible(data.type()) == TypeConsistency::EQUALS, "Types doesn't match");
+        return map.insert_instance(instance_, p_instance(data)) != nullptr;
+    }
+
+    /// \brief checks if a key is contained in the map represented by the DynamicData.
+    /// \pre The DynamicData must represent a MapType.
+    bool has_key(
+            ReadableDynamicDataRef key) const
+    {
+        xtypes_assert(
+            type_.kind() == TypeKind::MAP_TYPE,
+            "has_key method is only available for MapType.");
+
+        const MapType& map = static_cast<const MapType&>(type_);
+        const PairType& pair = static_cast<const PairType&>(map.content_type());
+        xtypes_assert(pair.first().is_compatible(key.type()) == TypeConsistency::EQUALS, "Key types doesn't match.");
+        return map.has_key(instance_, p_instance(key));
     }
 
     /// \brief Set a primitive or string value into the DynamicData
@@ -798,24 +903,31 @@ public:
         return *this;
     }
 
-    /// \brief resize the Sequence representing by the DynamicData.
+    /// \brief resize the Sequence or Map representing by the DynamicData.
     /// If size is less or equals that the current size, nothing happens,
     /// otherwise a default-initialized values are insert to the sequence to increase its size.
-    /// \param[int] size New sequence size
-    /// \pre The DynamicData must represent a SequenceType.
+    /// \param[int] size New sequence/map size
+    /// \pre The DynamicData must represent a SequenceType or a MapType.
     /// \pre The bounds must be greater or equal to the new size.
     /// \returns The writable reference to this DynamicData
-    WritableDynamicDataRef& resize(size_t size) // this = SequenceType
+    WritableDynamicDataRef& resize(size_t size) // this = SequenceType || MapType
     {
-        xtypes_assert(type_.kind() == TypeKind::SEQUENCE_TYPE,
-            "resize() is only available for sequence types but called for '" << type_.name() << "'.");
+        xtypes_assert(type_.kind() == TypeKind::SEQUENCE_TYPE || type_.kind() == TypeKind::MAP_TYPE,
+            "resize() is only available for sequence and map types but called for '" << type_.name() << "'.");
         size_t bound = bounds();
         xtypes_assert(!bound || bound >= size,
             "The desired size (" << size << ") is bigger than maximum allowed size for the type '"
             << type_.name() << "' (" << bounds() << ").");
-        const SequenceType& sequence = static_cast<const SequenceType&>(type_);
-
-        sequence.resize_instance(instance_, size);
+        if (type_.kind() == TypeKind::SEQUENCE_TYPE)
+        {
+            const SequenceType& sequence = static_cast<const SequenceType&>(type_);
+            sequence.resize_instance(instance_, size);
+        }
+        else
+        {
+            const MapType& map = static_cast<const MapType&>(type_);
+            map.resize_instance(instance_, size);
+        }
         return *this;
     }
 

--- a/include/xtypes/DynamicData.hpp
+++ b/include/xtypes/DynamicData.hpp
@@ -194,7 +194,7 @@ public:
     {
         xtypes_assert(
             type_.kind() == TypeKind::MAP_TYPE,
-            "operator[const DynamicData&] is only available for MapType.");
+            "'at()' method is only available for MapType.");
 
         const MapType& map = static_cast<const MapType&>(type_);
         const PairType& pair = static_cast<const PairType&>(map.content_type());
@@ -792,19 +792,8 @@ public:
         uint8_t* instance = map.get_instance_at(instance_, p_instance(data));
         if (instance == nullptr)
         {
-            uint8_t new_entry[pair.memory_size()] = {0};
-            if (pair.first().is_constructed_type())
-            {
-                pair.first().copy_instance(new_entry, p_instance(data));
-            }
-            else // Primitive Type
-            {
-                std::memcpy(new_entry, p_instance(data), pair.first().memory_size()); // Don't copy the "second" part.
-            }
-            uint8_t* result = map.insert_instance(instance_, new_entry);
-            xtypes_assert(result != nullptr, "Cannot insert new element into map.");
-            instance = result;
-            pair.second().construct_instance(instance + pair.first().memory_size()); // "second" part initilized here!
+            instance = map.insert_instance(instance_, p_instance(data));
+            xtypes_assert(instance != nullptr, "Cannot insert new element into map.");
         }
         return WritableDynamicDataRef(pair.second(), instance + pair.first().memory_size());
     }

--- a/include/xtypes/DynamicData.hpp
+++ b/include/xtypes/DynamicData.hpp
@@ -139,7 +139,7 @@ public:
     ReadableDynamicDataRef operator [] (
             size_t index) const
     {
-        xtypes_assert((type_.is_aggregation_type() || type_.is_collection_type()),
+        xtypes_assert(type_.is_aggregation_type() || type_.is_collection_type() || type_.kind() == TypeKind::PAIR_TYPE,
             "operator [size_t] isn't available for type '" << type_.name() << "'.");
         xtypes_assert(index < size(),
             "operator [" << index << "] is out of bounds.");
@@ -210,7 +210,7 @@ public:
     /// \returns Element size of the DynamicData.
     size_t size() const
     {
-        xtypes_assert(type_.is_collection_type() || type_.is_aggregation_type(),
+        xtypes_assert(type_.is_collection_type() || type_.is_aggregation_type() || type_.kind() == TypeKind::PAIR_TYPE,
             "size() isn't available for type '" << type_.name() << "'.");
         if(type_.is_collection_type())
         {
@@ -221,6 +221,10 @@ public:
         {
             const AggregationType& aggregation = static_cast<const AggregationType&>(type_);
             return aggregation.members().size();
+        }
+        if(type_.kind() == TypeKind::PAIR_TYPE)
+        {
+            return 2;
         }
         return 1;
     }

--- a/include/xtypes/DynamicData.hpp
+++ b/include/xtypes/DynamicData.hpp
@@ -242,6 +242,11 @@ public:
         return 0;
     }
 
+    uint64_t hash() const
+    {
+        return type_.hash(instance_);
+    }
+
     /// \brief Returns a std::vector representing the underlying collection of types.
     /// \pre The collection must have primitive or string values.
     /// \returns a std::vector representing the internal collection.

--- a/include/xtypes/DynamicData.hpp
+++ b/include/xtypes/DynamicData.hpp
@@ -146,6 +146,9 @@ public:
         if(type_.is_collection_type())
         {
             const CollectionType& collection = static_cast<const CollectionType&>(type_);
+            // The following assert exists because it may be confusing by the user, it will return the pair instead of
+            // the value associated to the "key" representation of the index.
+            xtypes_assert(type_.kind() != TypeKind::MAP_TYPE, "Cannot access a MapType by index");
             return ReadableDynamicDataRef(collection.content_type(), collection.get_instance_at(instance_, index));
         }
 

--- a/include/xtypes/DynamicDataImpl.hpp
+++ b/include/xtypes/DynamicDataImpl.hpp
@@ -101,6 +101,9 @@ inline std::string ReadableDynamicDataRef::to_string() const
             case TypeKind::SEQUENCE_TYPE:
                 ss << "<" << type_name << "[" << node.data().size() << "]>";
                 break;
+            case TypeKind::MAP_TYPE:
+                ss << "<" << type_name << "[" << node.data().size() << "]>";
+                break;
             case TypeKind::STRUCTURE_TYPE:
                 ss << "Structure: <" << type_name << ">";
                 break;

--- a/include/xtypes/MapInstance.hpp
+++ b/include/xtypes/MapInstance.hpp
@@ -265,15 +265,18 @@ private:
     {
         if(content_.first().is_constructed_type() || content_.second().is_constructed_type())
         {
-            if (overlap)
+            if (overlap && check_overlap(target, source))
             {
-                for(uint32_t i = size_; i > 0; --i)
+                // Creating a place
+                uint32_t to_move = size_ - get_key_index(source);
+                for(uint32_t i = to_move; i > 0; --i)
                 {
                     content_.move_instance(target + (i - 1) * block_size_, source + (i - 1) * block_size_);
                 }
             }
             else
             {
+                // Moving full memory
                 for(uint32_t i = 0; i < size_; ++i)
                 {
                     content_.move_instance(target + i * block_size_, source + i * block_size_);
@@ -284,6 +287,14 @@ private:
         {
             std::memmove(target, source, (size_ - get_key_index(source)) * block_size_);
         }
+    }
+
+    bool check_overlap(
+            const uint8_t* target,
+            const uint8_t* source) const
+    {
+        uint8_t* end = get_element(size_);
+        return source >= memory_ && target > source && end > target; // target and source are inside the block of memory
     }
 
     uint8_t* create_place(
@@ -306,7 +317,7 @@ private:
             const uint8_t* instance,
             bool exact = false) const
     {
-        uint64_t instance_hash;
+        uint64_t instance_hash = 0;
         // Special case, it is empty
         if (size_ == 0)
         {

--- a/include/xtypes/MapInstance.hpp
+++ b/include/xtypes/MapInstance.hpp
@@ -393,9 +393,13 @@ private:
     size_t get_key_index(
             const uint8_t* instance) const
     {
-        uint8_t* place = find_place(instance, true);
-        xtypes_assert(place != nullptr, "Key doesn't exists.");
-        return (place - memory_) / block_size_;
+        if (memory_ != nullptr)
+        {
+            uint8_t* place = find_place(instance, true);
+            xtypes_assert(place != nullptr, "Key doesn't exists.");
+            return (place - memory_) / block_size_;
+        }
+        return 0;
     }
 
     uint64_t hash(

--- a/include/xtypes/MapInstance.hpp
+++ b/include/xtypes/MapInstance.hpp
@@ -1,0 +1,410 @@
+/*
+ * Copyright 2020, Proyectos y Sistemas de Mantenimiento SL (eProsima).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef EPROSIMA_XTYPES_MAP_INSTANCE_HPP_
+#define EPROSIMA_XTYPES_MAP_INSTANCE_HPP_
+
+#include <xtypes/PairType.hpp>
+
+#include <cstdint>
+#include <cstring>
+
+namespace eprosima {
+namespace xtypes {
+
+/// \brief Implementation of a dynamic map of DynamicTypes.
+/// This class is used internal by MapType to implement its behaviour.
+class MapInstance
+{
+public:
+    /// \brief Construct a MapInstance
+    /// \param[in] content Content of the map
+    /// \param[in] capacity Reserved memory for the map.
+    MapInstance(
+            const PairType& content,
+            uint32_t capacity = 0)
+        : content_(content)
+        , block_size_(content.memory_size())
+        , capacity_(capacity)
+        , memory_(capacity > 0 ? new uint8_t[capacity * block_size_] : nullptr)
+        , size_(0)
+    {}
+
+    MapInstance(
+            const MapInstance& other)
+        : content_(other.content_)
+        , block_size_(other.block_size_)
+        , capacity_(other.capacity_)
+        , memory_(capacity_ > 0 ? new uint8_t[capacity_ * block_size_] : nullptr)
+        , size_(other.size_)
+    {
+        if(memory_ != nullptr)
+        {
+            copy_content(memory_, other.memory_);
+        }
+    }
+
+    /// \brief Copy constructor from a MapInstance with other but compatible content.
+    /// \param[in] other Map from copy the values.
+    /// \param[in] content Content of the map
+    /// \param[in] bounds Max copied elements.
+    /// \pre content and other.content compatibles (see dds::core::xtypes::DynamicType::is_compatible())
+    MapInstance(
+            const MapInstance& other,
+            const PairType& content,
+            uint32_t bounds)
+        : content_(content)
+        , block_size_(content.memory_size())
+        , capacity_(bounds == 0 ? other.capacity_ : std::min(other.capacity_, bounds))
+        , memory_(capacity_ > 0 ? new uint8_t[capacity_ * block_size_] : nullptr)
+        , size_(bounds == 0 ? other.size_ : std::min(other.size_, bounds))
+    {
+        if(memory_ != nullptr)
+        {
+            copy_content_from_type(memory_, other.memory_, other.content_);
+        }
+    }
+
+    MapInstance(
+            MapInstance&& other)
+        : content_(std::move(other.content_))
+        , block_size_(std::move(other.block_size_))
+        , capacity_(std::move(other.capacity_))
+        , memory_(std::move(other.memory_))
+        , size_(std::move(other.size_))
+    {
+        other.memory_ = nullptr;
+    }
+
+    /// \brief Deep equality operator
+    bool operator == (
+            const MapInstance& other) const
+    {
+        if(other.size() != size_)
+        {
+            return false;
+        }
+
+        if(content_.first().is_constructed_type() || content_.second().is_constructed_type())
+        {
+            bool comp = true;
+            for(uint32_t i = 0; i < size_; i++)
+            {
+                comp &= content_.compare_instance(memory_ + i * block_size_, other.memory_ + i * block_size_);
+            }
+            return comp;
+        }
+        else //optimization when the pair are both primitive
+        {
+            return std::memcmp(memory_, other.memory_, size_ * block_size_) == 0;
+        }
+    }
+
+    virtual ~MapInstance()
+    {
+        if(memory_ != nullptr)
+        {
+            if(content_.is_constructed_type())
+            {
+                uint32_t block_size = block_size_;
+                for(int32_t i = size_ - 1; i >= 0; i--)
+                {
+                    content_.destroy_instance(memory_ + i * block_size);
+                }
+            }
+
+            delete[] memory_;
+            memory_ = nullptr;
+        }
+    }
+
+    /// \brief Inserts an instance into the map
+    /// A reallocation can be done in order to allocate this new value.
+    /// A reorder can be done in order to keep the keys in order.
+    /// \param[in] instance Instance of the pair to insert into the map.
+    /// \returns Returns the location of the new instance added.
+    uint8_t* insert(
+            const uint8_t* instance)
+    {
+        if(size_ == capacity_)
+        {
+            realloc((capacity_ > 0) ? capacity_ * 2 : 1);
+        }
+
+        uint8_t* place = create_place(instance);
+        content_.copy_instance(place, instance);
+
+        size_++;
+
+        return place;
+    }
+
+    /// \brief Resize the map. All new elements will be default-initialized.
+    /// If the new size is equal or less than the current size, nothing happens.
+    /// \param[in] new_size New map size.
+    void resize(
+            size_t new_size)
+    {
+        if(size_ >= new_size)
+        {
+            return;
+        }
+
+        realloc(new_size);
+
+        for(size_t i = size_; i < new_size; i++)
+        {
+            uint8_t* place = memory_ + size_ * block_size_;
+            content_.construct_instance(place);
+        }
+
+        size_ = new_size;
+    }
+
+    /// \brief Key access operator.
+    /// \param[in] key_instance Requested key
+    /// \returns The pair instance with the key.
+    uint8_t* operator [] (
+            uint8_t* key_instance) const
+    {
+        return find_place(key_instance, true);
+    }
+
+    /// \brief Index access operator.
+    /// \param[in] index Requested index
+    /// \returns The pair at index.
+    uint8_t* operator [] (
+            uint32_t index) const
+    {
+        return get_element(index);
+    }
+
+    /// \brief Checks a key for existance
+    bool contains_key(
+            uint8_t* key_instance) const
+    {
+        return operator[](key_instance) != nullptr;
+    }
+
+    /// \brief Size of the map.
+    /// \returns Size of the map.
+    uint32_t size() const { return size_; }
+
+private:
+    const PairType& content_;
+    uint32_t block_size_;
+    uint32_t capacity_;
+    uint8_t* memory_;
+    uint32_t size_;
+
+    void realloc(size_t new_capacity)
+    {
+        uint8_t* new_memory = new uint8_t[new_capacity * block_size_];
+
+        move_content(new_memory, memory_);
+
+        delete[] memory_;
+        memory_ = new_memory;
+        capacity_ = new_capacity;
+    }
+
+    void copy_content(
+            uint8_t* target,
+            const uint8_t* source) const
+    {
+        if(content_.is_constructed_type())
+        {
+            for(uint32_t i = 0; i < size_; i++)
+            {
+                content_.copy_instance(target + i * block_size_, source + i * block_size_);
+            }
+        }
+        else //optimization when the type is primitive
+        {
+            std::memcpy(target, source, size_ * block_size_);
+        }
+    }
+
+    void copy_content_from_type(
+            uint8_t* target,
+            const uint8_t* source,
+            const PairType& other_content) const
+    {
+        size_t other_first_size = other_content.first().memory_size();
+        size_t other_second_size = other_content.second().memory_size();
+        if(content_.first().is_constructed_type()
+            || content_.second().is_constructed_type()
+            || content_.first().memory_size() != other_first_size
+            || content_.second().memory_size() != other_second_size)
+        {
+            for(uint32_t i = 0; i < size_; i++)
+            {
+                content_.copy_instance_from_type(
+                        target + i * block_size_,
+                        source + i * other_content.memory_size(),
+                        other_content);
+            }
+        }
+        else //optimization when the pair are both primitive with same size
+        {
+            std::memcpy(target, source, size_ * block_size_);
+        }
+    }
+
+    void move_content(
+            uint8_t* target,
+            uint8_t* source,
+            bool overlap = false)
+    {
+        if(content_.first().is_constructed_type() || content_.second().is_constructed_type())
+        {
+            if (overlap)
+            {
+                for(uint32_t i = size_ - 1; i >= 0; --i)
+                {
+                    content_.move_instance(target + i * block_size_, source + i * block_size_);
+                }
+            }
+            else
+            {
+                for(uint32_t i = 0; i < size_; ++i)
+                {
+                    content_.move_instance(target + i * block_size_, source + i * block_size_);
+                }
+            }
+        }
+        else //optimization when the pair are both primitive
+        {
+            std::memmove(target, source, size_ * block_size_);
+        }
+    }
+
+    uint8_t* create_place(
+            const uint8_t* instance)
+    {
+        uint8_t* place = find_place(instance);
+        xtypes_assert(hash(instance) != hash(place), "Key already exists.");
+        move_content(place + block_size_, place, true);
+        return place;
+    }
+
+    uint8_t* find_place(
+            const uint8_t* instance,
+            bool exact = false) const
+    {
+        // Binary search by hash
+        uint64_t istart = 0;
+        uint64_t iend = size_;
+        uint64_t icurrent = (istart + iend) / 2;
+        uint64_t instance_hash = hash(instance);
+        uint8_t* start = get_element(0);
+        uint8_t* end = get_element(size_);
+        uint8_t* current = get_element(icurrent);
+
+        while (icurrent != istart)
+        {
+            uint64_t current_hash = hash(current);
+            if (instance_hash == current_hash)
+            {
+                return current;
+            }
+            else if (instance_hash > current_hash)
+            {
+                start = current;
+                istart = icurrent;
+            }
+            else
+            {
+                end = current;
+                iend = icurrent;
+            }
+
+            icurrent = (istart + iend) / 2;
+            current = get_element(icurrent);
+        }
+
+        if (exact && hash(current) != instance_hash)
+        {
+            return nullptr;
+        }
+        return current;
+    }
+
+    uint8_t* get_element(
+            size_t index) const
+    {
+        return memory_ + index * block_size_;
+    }
+
+    uint64_t hash(
+            const uint8_t* instance) const
+    {
+        return hash64(instance, content_.first().memory_size(), 0x2145654af87a5b6dULL);
+    }
+
+    // Hash function based on fasthash (https://github.com/ZilongTan/fast-hash)
+    uint64_t& mix(
+            uint64_t& h) const
+    {
+        h ^= (h >> 23);
+        h *= 0x2127599bf4325c37ULL;
+        h ^= (h >> 47);
+        return h;
+    }
+
+    uint64_t hash64(
+            const uint8_t* buf,
+            size_t len,
+            uint64_t seed) const
+    {
+        const uint64_t m = 0x880355f21e6d1965ULL;
+        uint64_t* pos = reinterpret_cast<uint64_t*>(const_cast<uint8_t*>(buf));
+        const uint64_t* end = pos + (len / 8);
+        const uint8_t* pos2;
+        uint64_t h = seed ^ (len * m);
+        uint64_t v;
+
+        while (pos != end)
+        {
+            v = *pos++;
+            h ^= mix(v);
+            h *= m;
+        }
+
+        pos2 = reinterpret_cast<uint8_t*>(pos);
+        v = 0;
+
+        switch (len & 7)
+        {
+        case 7: v ^= static_cast<uint64_t>(pos2[6]) << 48;
+        case 6: v ^= static_cast<uint64_t>(pos2[6]) << 48;
+        case 5: v ^= static_cast<uint64_t>(pos2[6]) << 48;
+        case 4: v ^= static_cast<uint64_t>(pos2[6]) << 48;
+        case 3: v ^= static_cast<uint64_t>(pos2[6]) << 48;
+        case 2: v ^= static_cast<uint64_t>(pos2[6]) << 48;
+        case 1: v ^= static_cast<uint64_t>(pos2[6]) << 48;
+            h ^= mix(v);
+            h *= m;
+        }
+
+        return mix(h);
+    }
+};
+
+} //namespace xtypes
+} //namespace eprosima
+
+#endif //EPROSIMA_XTYPES_MAP_INSTANCE_HPP_

--- a/include/xtypes/MapType.hpp
+++ b/include/xtypes/MapType.hpp
@@ -114,8 +114,7 @@ public:
             uint8_t* instance,
             size_t index) const override
     {
-        xtypes_assert(false, "Cannot access a MapType by index");
-        return nullptr;
+        return reinterpret_cast<MapInstance*>(instance)->operator[](uint32_t(index));
     }
 
     virtual uint8_t* get_instance_at(

--- a/include/xtypes/MapType.hpp
+++ b/include/xtypes/MapType.hpp
@@ -88,12 +88,13 @@ public:
             const uint8_t* source,
             const DynamicType& other) const override
     {
-        xtypes_assert(other.kind() == TypeKind::MAP_TYPE,
+        xtypes_assert(
+            other.kind() == TypeKind::MAP_TYPE
+                && content_type().name() == static_cast<const MapType&>(other).content_type().name(),
             "Cannot copy data from different types: From '" << other.name() << "' to '" << name() << "'.");
         (void) other;
         new (target) MapInstance(
             *reinterpret_cast<const MapInstance*>(source),
-            static_cast<const PairType&>(content_type()),
             bounds());
     }
 
@@ -182,16 +183,16 @@ public:
 
     /// \brief Push a value to a map instance.
     /// \param[in, out] instance Memory instance representing a MapInstance.
-    /// \param[in] value to add into the map.
+    /// \param[in] new key instance to add into the map.
     /// \returns a instance location representing the new value added
     /// or nullptr if the map reach the limit.
     uint8_t* insert_instance(
             uint8_t* instance,
-            const uint8_t* value) const
+            const uint8_t* key_instance) const
     {
         if(get_instance_size(instance) < bounds() || bounds() == 0)
         {
-            return reinterpret_cast<MapInstance*>(instance)->insert(value);
+            return reinterpret_cast<MapInstance*>(instance)->insert(key_instance);
         }
         return nullptr;
     }

--- a/include/xtypes/MapType.hpp
+++ b/include/xtypes/MapType.hpp
@@ -1,0 +1,231 @@
+/*
+ * Copyright 2020, Proyectos y Sistemas de Mantenimiento SL (eProsima).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+#ifndef EPROSIMA_XTYPES_MAP_TYPE_HPP_
+#define EPROSIMA_XTYPES_MAP_TYPE_HPP_
+
+#include <xtypes/MutableCollectionType.hpp>
+#include <xtypes/MapInstance.hpp>
+
+#include <vector>
+
+namespace eprosima {
+namespace xtypes {
+
+/// \brief DynamicType representing mutable map of elements.
+/// A MapType represents a TypeKind::MAP_TYPE.
+class MapType : public MutableCollectionType
+{
+public:
+    /// \brief Construct a MapType.
+    /// \param[in] key Key type of the map.
+    /// \param[in] content Content type of the map.
+    /// \param[in] bounds Size limit of the map, 0 means that no limits.
+    explicit MapType(
+            const DynamicType& key,
+            const DynamicType& content,
+            uint32_t bounds = 0)
+        : MutableCollectionType(
+                TypeKind::MAP_TYPE,
+                "map_" + ((bounds > 0) ? std::to_string(bounds) + "_" : "") + PairType::name(key, content),
+                DynamicType::Ptr(PairType(key, content)),
+                bounds)
+    {}
+
+    /// \brief Construct a MapType.
+    /// \param[in] key Key type of the map.
+    /// \param[in] content Content type of the map.
+    /// \param[in] bounds Size limit of the map, 0 means that no limits.
+    template<typename DynamicTypeImpl>
+    MapType(
+            const DynamicTypeImpl&& key,
+            const DynamicTypeImpl&& content,
+            uint32_t bounds)
+        : MutableCollectionType(
+                TypeKind::MAP_TYPE,
+                "map_" + ((bounds > 0) ? std::to_string(bounds) + "_" : "") + PairType::name(key, content),
+                DynamicType::Ptr(PairType(key, content)),
+                bounds)
+    {}
+
+    MapType(const MapType& other) = default;
+    MapType(MapType&& other) = default;
+
+    virtual size_t memory_size() const override
+    {
+        return sizeof(MapInstance);
+    }
+
+    virtual void construct_instance(
+            uint8_t* instance) const override
+    {
+        new (instance) MapInstance(static_cast<const PairType&>(content_type()), bounds());
+    }
+
+    virtual void copy_instance(
+            uint8_t* target,
+            const uint8_t* source) const override
+    {
+        new (target) MapInstance(*reinterpret_cast<const MapInstance*>(source));
+    }
+
+    virtual void copy_instance_from_type(
+            uint8_t* target,
+            const uint8_t* source,
+            const DynamicType& other) const override
+    {
+        xtypes_assert(other.kind() == TypeKind::MAP_TYPE,
+            "Cannot copy data from different types: From '" << other.name() << "' to '" << name() << "'.");
+        (void) other;
+        new (target) MapInstance(
+            *reinterpret_cast<const MapInstance*>(source),
+            static_cast<const PairType&>(content_type()),
+            bounds());
+    }
+
+    virtual void move_instance(
+            uint8_t* target,
+            uint8_t* source) const override
+    {
+        new (target) MapInstance(std::move(*reinterpret_cast<const MapInstance*>(source)));
+    }
+
+    virtual void destroy_instance(
+            uint8_t* instance) const override
+    {
+        reinterpret_cast<MapInstance*>(instance)->~MapInstance();
+    }
+
+    virtual uint8_t* get_instance_at(
+            uint8_t* instance,
+            size_t index) const override
+    {
+        xtypes_assert(false, "Cannot access a MapType by index");
+        return nullptr;
+    }
+
+    virtual uint8_t* get_instance_at(
+            uint8_t* instance,
+            uint8_t* key_instance) const
+    {
+        return reinterpret_cast<MapInstance*>(instance)->operator[](key_instance);
+    }
+
+    virtual size_t get_instance_size(
+            const uint8_t* instance) const override
+    {
+        return reinterpret_cast<const MapInstance*>(instance)->size();
+    }
+
+    virtual bool compare_instance(
+            const uint8_t* instance,
+            const uint8_t* other_instance) const override
+    {
+        return *reinterpret_cast<const MapInstance*>(instance)
+            == *reinterpret_cast<const MapInstance*>(other_instance);
+    }
+
+    virtual TypeConsistency is_compatible(
+            const DynamicType& other) const override
+    {
+        if(other.kind() != TypeKind::MAP_TYPE)
+        {
+            return TypeConsistency::NONE;
+        }
+
+        const MapType& other_map = static_cast<const MapType&>(other);
+
+        if(bounds() == other_map.bounds())
+        {
+            return TypeConsistency::EQUALS
+                | content_type().is_compatible(other_map.content_type());
+        }
+
+        return TypeConsistency::IGNORE_MAP_BOUNDS
+            | content_type().is_compatible(other_map.content_type());
+    }
+
+    virtual void for_each_instance(
+            const InstanceNode& node,
+            InstanceVisitor visitor) const override
+    {
+        const MapInstance& map = *reinterpret_cast<const MapInstance*>(node.instance);
+        visitor(node);
+        for(uint32_t i = 0; i < map.size(); i++)
+        {
+            InstanceNode child(node, content_type(), map[i], i, nullptr);
+            content_type().for_each_instance(child, visitor);
+        }
+    }
+
+    virtual void for_each_type(
+            const TypeNode& node,
+            TypeVisitor visitor) const override
+    {
+        visitor(node);
+        TypeNode child(node, content_type(), 0, nullptr);
+        content_type().for_each_type(child, visitor);
+    }
+
+    /// \brief Push a value to a map instance.
+    /// \param[in, out] instance Memory instance representing a MapInstance.
+    /// \param[in] value to add into the map.
+    /// \returns a instance location representing the new value added
+    /// or nullptr if the map reach the limit.
+    uint8_t* insert_instance(
+            uint8_t* instance,
+            const uint8_t* value) const
+    {
+        if(get_instance_size(instance) < bounds() || bounds() == 0)
+        {
+            return reinterpret_cast<MapInstance*>(instance)->insert(value);
+        }
+        return nullptr;
+    }
+
+    /// \brief Resize a map instance to reach the requested size.
+    /// All new values needed will be default-initialized
+    /// \param[in, out] instance Memory instance representing a MapInstance.
+    /// \param[in] size new map instance size.
+    void resize_instance(
+            uint8_t* instance,
+            size_t size) const
+    {
+        reinterpret_cast<MapInstance*>(instance)->resize(size);
+    }
+
+    /// \brief checks if a key is contained in the map.
+    bool has_key(
+            uint8_t* instance,
+            uint8_t* key) const
+    {
+        return reinterpret_cast<MapInstance*>(instance)->contains_key(key);
+    }
+
+protected:
+    DynamicType::Ptr key_;
+
+    virtual DynamicType* clone() const override
+    {
+        return new MapType(*this);
+    }
+};
+
+} //namespace xtypes
+} //namespace eprosima
+
+#endif //EPROSIMA_XTYPES_MAP_TYPE_HPP_

--- a/include/xtypes/MapType.hpp
+++ b/include/xtypes/MapType.hpp
@@ -197,23 +197,19 @@ public:
         return nullptr;
     }
 
-    /// \brief Resize a map instance to reach the requested size.
-    /// All new values needed will be default-initialized
-    /// \param[in, out] instance Memory instance representing a MapInstance.
-    /// \param[in] size new map instance size.
-    void resize_instance(
-            uint8_t* instance,
-            size_t size) const
-    {
-        reinterpret_cast<MapInstance*>(instance)->resize(size);
-    }
-
     /// \brief checks if a key is contained in the map.
     bool has_key(
             uint8_t* instance,
             uint8_t* key) const
     {
         return reinterpret_cast<MapInstance*>(instance)->contains_key(key);
+    }
+
+    virtual uint64_t hash(
+            const uint8_t* c_instance) const override
+    {
+        uint8_t* instance = const_cast<uint8_t*>(c_instance);
+        return reinterpret_cast<MapInstance*>(instance)->map_hash();
     }
 
 protected:

--- a/include/xtypes/MapType.hpp
+++ b/include/xtypes/MapType.hpp
@@ -212,8 +212,6 @@ public:
     }
 
 protected:
-    DynamicType::Ptr key_;
-
     virtual DynamicType* clone() const override
     {
         return new MapType(*this);

--- a/include/xtypes/PairType.hpp
+++ b/include/xtypes/PairType.hpp
@@ -144,9 +144,18 @@ public:
             TypeVisitor visitor) const override
     {
         visitor(node);
-        TypeNode f(node, first(), 0, nullptr);
+        Member* from_member = nullptr;
+        if (node.from_member() != nullptr)
+        {
+            from_member = const_cast<Member*>(node.from_member());
+        }
+        else if (node.has_parent())
+        {
+            from_member = const_cast<Member*>(node.parent().from_member());
+        }
+        TypeNode f(node, first(), 0, from_member);
         first_->for_each_type(f, visitor);
-        TypeNode s(node, second(), 1, nullptr);
+        TypeNode s(node, second(), 1, from_member);
         second_->for_each_type(s, visitor);
     }
 
@@ -155,9 +164,18 @@ public:
             InstanceVisitor visitor) const override
     {
         visitor(node);
-        InstanceNode f(node, first(), node.instance, 0, nullptr);
+        Member* from_member = nullptr;
+        if (node.from_member != nullptr)
+        {
+            from_member = const_cast<Member*>(node.from_member);
+        }
+        else if (node.parent != nullptr)
+        {
+            from_member = const_cast<Member*>(node.parent->from_member);
+        }
+        InstanceNode f(node, first(), node.instance, 0, from_member);
         first_->for_each_instance(f, visitor);
-        InstanceNode s(node, second(), node.instance + first_->memory_size(), 1, nullptr);
+        InstanceNode s(node, second(), node.instance + first_->memory_size(), 1, from_member);
         second_->for_each_instance(s, visitor);
     }
 

--- a/include/xtypes/PairType.hpp
+++ b/include/xtypes/PairType.hpp
@@ -1,0 +1,178 @@
+/*
+ * Copyright 2020, Proyectos y Sistemas de Mantenimiento SL (eProsima).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+#ifndef EPROSIMA_XTYPES_PAIR_TYPE_HPP_
+#define EPROSIMA_XTYPES_PAIR_TYPE_HPP_
+
+#include <xtypes/DynamicType.hpp>
+
+namespace eprosima {
+namespace xtypes {
+
+class PairType : public DynamicType
+{
+public:
+    /// \brief Construct a PairType
+    PairType(
+            const DynamicType& first,
+            const DynamicType& second)
+        : DynamicType (TypeKind::PAIR_TYPE, "pair_" + first.name() + "_" + second.name())
+        , first_(first)
+        , second_(second)
+    {
+    }
+
+    static std::string name(
+            const DynamicType& first,
+            const DynamicType& second)
+    {
+        return "pair_" + first.name() + "_" + second.name();
+    }
+
+    const DynamicType& first() const
+    {
+        return *first_;
+    }
+
+    const DynamicType& second() const
+    {
+        return *second_;
+    }
+
+    void first(const DynamicType& first)
+    {
+        first_ = DynamicType::Ptr(first);
+    }
+
+    void first(DynamicType&& first)
+    {
+        first_ = DynamicType::Ptr(std::move(first));
+    }
+
+    void second(const DynamicType& second)
+    {
+        second_ = DynamicType::Ptr(second);
+    }
+
+    void second(DynamicType&& second)
+    {
+        second_ = DynamicType::Ptr(std::move(second));
+    }
+
+    virtual size_t memory_size() const override
+    {
+        return first_->memory_size() + second_->memory_size();
+    }
+
+    virtual void construct_instance(
+            uint8_t* instance) const override
+    {
+        first_->construct_instance(instance);
+        second_->construct_instance(instance + first_->memory_size());
+    }
+
+    virtual void copy_instance(
+            uint8_t* target,
+            const uint8_t* source) const override
+    {
+        first_->copy_instance(target, source);
+        second_->copy_instance(target + first_->memory_size(), source + first_->memory_size());
+    }
+
+    virtual void copy_instance_from_type(
+            uint8_t* target,
+            const uint8_t* source,
+            const DynamicType& other) const override
+    {
+        first_->copy_instance_from_type(target, source, other);
+        second_->copy_instance_from_type(target + first_->memory_size(), source + first_->memory_size(), other);
+    }
+
+    virtual void move_instance(
+            uint8_t* target,
+            uint8_t* source) const override
+    {
+        first_->move_instance(target, source);
+        second_->move_instance(target + first_->memory_size(), source + first_->memory_size());
+    }
+
+    virtual void destroy_instance(
+            uint8_t* instance) const override
+    {
+        first_->destroy_instance(instance);
+        second_->destroy_instance(instance + first_->memory_size());
+    }
+
+    virtual bool compare_instance(
+            const uint8_t* instance,
+            const uint8_t* other_instance) const override
+    {
+        return
+            first_->compare_instance(instance, other_instance) &&
+            second_->compare_instance(instance + first_->memory_size(), other_instance + first_->memory_size());
+    }
+
+    virtual TypeConsistency is_compatible(
+            const DynamicType& other) const override
+    {
+        bool check = other.kind() == TypeKind::PAIR_TYPE;
+
+        if (check)
+        {
+            const PairType& pair = static_cast<const PairType&>(other);
+            return first_->is_compatible(pair.first()) | second_->is_compatible(pair.second());
+        }
+        return TypeConsistency::NONE;
+    }
+
+    virtual void for_each_type(
+            const TypeNode& node,
+            TypeVisitor visitor) const override
+    {
+        visitor(node);
+        TypeNode f(node, first(), 0, nullptr);
+        first_->for_each_type(f, visitor);
+        TypeNode s(node, second(), 1, nullptr);
+        second_->for_each_type(s, visitor);
+    }
+
+    virtual void for_each_instance(
+            const InstanceNode& node,
+            InstanceVisitor visitor) const override
+    {
+        visitor(node);
+        InstanceNode f(node, first(), node.instance, 0, nullptr);
+        first_->for_each_instance(f, visitor);
+        InstanceNode s(node, second(), node.instance + first_->memory_size(), 1, nullptr);
+        second_->for_each_instance(s, visitor);
+    }
+
+protected:
+    DynamicType::Ptr first_;
+    DynamicType::Ptr second_;
+
+    virtual DynamicType* clone() const override
+    {
+        return new PairType(*this);
+    }
+
+};
+
+} // namespace xtypes
+} // namespace eprosima
+
+#endif // EPROSIMA_XTYPES_PAIR_TYPE_HPP_

--- a/include/xtypes/PairType.hpp
+++ b/include/xtypes/PairType.hpp
@@ -161,6 +161,14 @@ public:
         second_->for_each_instance(s, visitor);
     }
 
+    virtual uint64_t hash(
+            const uint8_t* instance) const override
+    {
+        uint64_t h = first_->hash(instance);
+        Instanceable::hash_combine(h, second_->hash(instance + first_->memory_size()));
+        return h;
+    }
+
 protected:
     DynamicType::Ptr first_;
     DynamicType::Ptr second_;

--- a/include/xtypes/SequenceType.hpp
+++ b/include/xtypes/SequenceType.hpp
@@ -32,7 +32,7 @@ class SequenceType : public MutableCollectionType
 {
 public:
     /// \brief Construct a SequenceType.
-    /// \param[in] content Content type of the array.
+    /// \param[in] content Content type of the sequence.
     /// \param[in] bounds Size limit of the sequence, 0 means that no limits.
     explicit SequenceType(
             const DynamicType& content,
@@ -45,7 +45,7 @@ public:
     {}
 
     /// \brief Construct a SequenceType.
-    /// \param[in] content Content type of the array.
+    /// \param[in] content Content type of the sequence.
     /// \param[in] bounds Size limit of the sequence, 0 means that no limits.
     template<typename DynamicTypeImpl>
     SequenceType(

--- a/include/xtypes/SequenceType.hpp
+++ b/include/xtypes/SequenceType.hpp
@@ -193,6 +193,25 @@ public:
         reinterpret_cast<SequenceInstance*>(instance)->resize(size);
     }
 
+    virtual uint64_t hash(
+            const uint8_t* c_instance) const override
+    {
+        uint8_t* instance = const_cast<uint8_t*>(c_instance);
+        if (content_type().is_constructed_type())
+        {
+            uint64_t h = content_type().hash(instance);
+            for (size_t i = 1; i < bounds(); ++i)
+            {
+                Instanceable::hash_combine(h, content_type().hash(get_instance_at(instance, i)));
+            }
+            return h;
+        }
+        else
+        {
+            return Instanceable::hash(instance);
+        }
+    }
+
 protected:
     virtual DynamicType* clone() const override
     {

--- a/include/xtypes/SequenceType.hpp
+++ b/include/xtypes/SequenceType.hpp
@@ -196,20 +196,24 @@ public:
     virtual uint64_t hash(
             const uint8_t* c_instance) const override
     {
-        uint8_t* instance = const_cast<uint8_t*>(c_instance);
-        if (content_type().is_constructed_type())
+        if (bounds() > 0)
         {
-            uint64_t h = content_type().hash(instance);
-            for (size_t i = 1; i < bounds(); ++i)
+            uint8_t* instance = const_cast<uint8_t*>(c_instance);
+            if (content_type().is_constructed_type())
             {
-                Instanceable::hash_combine(h, content_type().hash(get_instance_at(instance, i)));
+                uint64_t h = content_type().hash(instance);
+                for (size_t i = 1; i < bounds(); ++i)
+                {
+                    Instanceable::hash_combine(h, content_type().hash(get_instance_at(instance, i)));
+                }
+                return h;
             }
-            return h;
+            else
+            {
+                return Instanceable::hash(instance);
+            }
         }
-        else
-        {
-            return Instanceable::hash(instance);
-        }
+        return 0;
     }
 
 protected:

--- a/include/xtypes/StringType.hpp
+++ b/include/xtypes/StringType.hpp
@@ -88,7 +88,6 @@ public:
     virtual void destroy_instance(
             uint8_t* instance) const override
     {
-        using namespace std;
         reinterpret_cast<std::basic_string<CHAR_T>*>(instance)->std::basic_string<CHAR_T>::~basic_string<CHAR_T>();
     }
 
@@ -144,6 +143,13 @@ public:
             const uint8_t* instance) const override
     {
         return reinterpret_cast<const std::basic_string<CHAR_T>*>(instance)->size();
+    }
+
+    virtual uint64_t hash(
+            const uint8_t* instance) const override
+    {
+        std::hash<std::basic_string<CHAR_T>> hash_fn;
+        return hash_fn(*reinterpret_cast<const std::basic_string<CHAR_T>*>(instance));
     }
 
 protected:

--- a/include/xtypes/StructType.hpp
+++ b/include/xtypes/StructType.hpp
@@ -248,6 +248,22 @@ public:
         }
     }
 
+    virtual uint64_t hash(
+            const uint8_t* instance) const override
+    {
+        if (members().size() > 0)
+        {
+            uint64_t h = member(0).type().hash(instance + member(0).offset());
+            for (size_t i = 1; i < members().size(); ++i)
+            {
+                const Member& m = member(i);
+                Instanceable::hash_combine(h, m.type().hash(instance + m.offset()));
+            }
+            return h;
+        }
+        return 0;
+    }
+
 protected:
     virtual DynamicType* clone() const override
     {

--- a/include/xtypes/TypeConsistency.hpp
+++ b/include/xtypes/TypeConsistency.hpp
@@ -54,6 +54,9 @@ enum class TypeConsistency
 
     /// \brief Ignore some members is required to interpret the types as equivalents.
     IGNORE_MEMBERS = 64,
+
+    /// \brief Ignore map bounds is required to interpret the types as equivalents.
+    IGNORE_MAP_BOUNDS = 128,
 };
 
 /// \brief OR operator

--- a/include/xtypes/TypeKind.hpp
+++ b/include/xtypes/TypeKind.hpp
@@ -59,12 +59,14 @@ enum class TypeKind
     SEQUENCE_TYPE    = CONSTRUCTED_TYPE | COLLECTION_TYPE | 0x0005, ///< Reprensets a SequenceType
     STRING_TYPE      = CONSTRUCTED_TYPE | COLLECTION_TYPE | 0x0006, ///< Represents a StringType
     WSTRING_TYPE     = CONSTRUCTED_TYPE | COLLECTION_TYPE | 0x0007, ///< Represents a WStringType
-    MAP_TYPE         = CONSTRUCTED_TYPE | COLLECTION_TYPE | 0x0008, ///< Not supported
+    MAP_TYPE         = CONSTRUCTED_TYPE | COLLECTION_TYPE | 0x0008, ///< Represents a MapType
 
     UNION_TYPE                = CONSTRUCTED_TYPE | AGGREGATION_TYPE | 0x0009, ///< Represents an UnionType
     STRUCTURE_TYPE            = CONSTRUCTED_TYPE | AGGREGATION_TYPE | 0x000A, ///< Represents a StructType
     UNION_FWD_DECL_TYPE       = CONSTRUCTED_TYPE | AGGREGATION_TYPE | 0x000B, ///< Not supported
-    STRUCTURE_FWD_DECL_TYPE   = CONSTRUCTED_TYPE | AGGREGATION_TYPE | 0x000C ///< Not supported
+    STRUCTURE_FWD_DECL_TYPE   = CONSTRUCTED_TYPE | AGGREGATION_TYPE | 0x000C, ///< Not supported
+
+    PAIR_TYPE                 = CONSTRUCTED_TYPE | AGGREGATION_TYPE | 0x000F ///< Represents a PairType
 };
 
 /// \brief OR operator

--- a/include/xtypes/TypeKind.hpp
+++ b/include/xtypes/TypeKind.hpp
@@ -66,7 +66,7 @@ enum class TypeKind
     UNION_FWD_DECL_TYPE       = CONSTRUCTED_TYPE | AGGREGATION_TYPE | 0x000B, ///< Not supported
     STRUCTURE_FWD_DECL_TYPE   = CONSTRUCTED_TYPE | AGGREGATION_TYPE | 0x000C, ///< Not supported
 
-    PAIR_TYPE                 = CONSTRUCTED_TYPE | AGGREGATION_TYPE | 0x000F ///< Represents a PairType
+    PAIR_TYPE                 = CONSTRUCTED_TYPE | 0x000F ///< Represents a PairType
 };
 
 /// \brief OR operator

--- a/include/xtypes/UnionType.hpp
+++ b/include/xtypes/UnionType.hpp
@@ -403,6 +403,17 @@ public:
         }
     }
 
+    virtual uint64_t hash(
+            const uint8_t* instance) const override
+    {
+        uint64_t h = disc()->type().hash(instance);
+        if (active_member_ != nullptr)
+        {
+            Instanceable::hash_combine(h, active_member_->type().hash(instance + active_member_->offset()));
+        }
+        return h;
+    }
+
 protected:
     friend DynamicData;
     friend ReadableDynamicDataRef;

--- a/include/xtypes/idl/generator.hpp
+++ b/include/xtypes/idl/generator.hpp
@@ -47,6 +47,20 @@ inline std::string sequence_type_name(const DynamicType& type)
     return ss.str();
 }
 
+inline std::string map_type_name(const DynamicType& type)
+{
+    assert(type.kind() == TypeKind::MAP_TYPE);
+    const MapType& map_type = static_cast<const MapType&>(type);
+    const PairType& map_content = static_cast<const PairType&>(map_type.content_type());
+    size_t bounds = map_type.bounds();
+    std::stringstream ss;
+    ss << "map<";
+    ss << type_name(map_content.first()) << ", " << type_name(map_content.second());
+    ss << (bounds ? ", " + std::to_string(bounds) : "");
+    ss << ">";
+    return ss.str();
+}
+
 inline std::string array_member(const Member& member)
 {
     assert(member.type().kind() == TypeKind::ARRAY_TYPE);
@@ -100,6 +114,10 @@ inline std::string type_name(const DynamicType& type)
     else if(type.kind() == TypeKind::SEQUENCE_TYPE)
     {
         return sequence_type_name(type);
+    }
+    else if(type.kind() == TypeKind::MAP_TYPE)
+    {
+        return map_type_name(type);
     }
     else if(type.kind() == TypeKind::STRING_TYPE || type.kind() == TypeKind::WSTRING_TYPE)
     {

--- a/include/xtypes/idl/parser.hpp
+++ b/include/xtypes/idl/parser.hpp
@@ -1670,13 +1670,7 @@ private:
                 {
                     size = get_dimension(outer, node->nodes[2]);
                 }
-                context_->log(log::LogLevel::WARNING, "UNSUPPORTED",
-                    "Found \"map<" + key_type->name() + ", " + inner_type->name()
-                    + ((size > 0) ? (", " + std::to_string(size)) : "") + ">\" "
-                    + "but maps aren't supported. Ignoring.",
-                    node);
-                break;
-                // return MapType(*key_type, *inner_type, size); // TODO, uncomment when maps are implemented.
+                return MapType(*key_type, *inner_type, size);
             }
             default:
                 return type_spec(node, outer);

--- a/test/unitary/parser/parser_test.cpp
+++ b/test/unitary/parser/parser_test.cpp
@@ -1286,6 +1286,7 @@ TEST (IDLParser, map_tests)
             map<string, MyChar> map_3;
             map<MyChar, float> map_4;
             map<MyEnum, KeyStruct> map_5;
+            map<string, map<uint32, string>> map_6;
         };
 
                    )");
@@ -1305,6 +1306,8 @@ TEST (IDLParser, map_tests)
     DynamicData map_3_key(str_type);
     DynamicData map_4_key(my_alias);
     DynamicData map_5_key(my_enum);
+    DynamicData map_6_key(str_type);
+    DynamicData map_6_inner_key(primitive_type<uint32_t>());
 
     DynamicData key_data(my_key);
     DynamicData enum_data(my_enum);
@@ -1337,6 +1340,13 @@ TEST (IDLParser, map_tests)
     map_5_key = my_enum.value("BBB");
     data["map_5"][map_5_key] = key_data;
 
+    map_6_key = "OuterMapKey_1";
+    map_6_inner_key = 550u;
+    data["map_6"][map_6_key][map_6_inner_key] = "I'm a map of maps!";
+    map_6_key = "OuterMapKey_2";
+    map_6_inner_key = 666u;
+    data["map_6"][map_6_key][map_6_inner_key] = "I'm a map of maps, but infernal!";
+
     // Check everything worked as expected.
     map_1_key = uint32_t(55);
     EXPECT_EQ(data["map_1"][map_1_key].value<std::string>(), "This is a simple map");
@@ -1364,6 +1374,14 @@ TEST (IDLParser, map_tests)
     key_data["my_string"] = "BBB String";
     map_5_key = my_enum.value("BBB");
     EXPECT_EQ(data["map_5"][map_5_key]["my_string"].value<std::string>(), "BBB String");
+
+    map_6_key = "OuterMapKey_1";
+    map_6_inner_key = 550u;
+    EXPECT_EQ(data["map_6"][map_6_key][map_6_inner_key].value<std::string>(), "I'm a map of maps!");
+    map_6_key = "OuterMapKey_2";
+    map_6_inner_key = 666u;
+    EXPECT_EQ(data["map_6"][map_6_key][map_6_inner_key].value<std::string>(), "I'm a map of maps, but infernal!");
+
 }
 
 int main(int argc, char** argv)

--- a/test/unitary/parser/roundtrip.cpp
+++ b/test/unitary/parser/roundtrip.cpp
@@ -93,6 +93,19 @@ void check_result(
         ASSERT_EQ(inner_inner_type.content_type().kind(), TypeKind::INT_64_TYPE);
         ASSERT_EQ(inner_inner_type.dimension(), 4);
     }
+    {
+        // map<RootEnum, sequence<int16>> my_map;
+        const Member& member = root_struct.member("my_map");
+        ASSERT_EQ(member.type().kind(), TypeKind::MAP_TYPE);
+        const MapType& inner_type = static_cast<const MapType&>(member.type());
+        const PairType& content_type = static_cast<const PairType&>(inner_type.content_type());
+        ASSERT_EQ(content_type.first().kind(), TypeKind::ENUMERATION_TYPE);
+        ASSERT_EQ(content_type.first().name(), "RootEnum");
+        ASSERT_EQ(content_type.second().kind(), TypeKind::SEQUENCE_TYPE);
+        const SequenceType& seq_type = static_cast<const SequenceType&>(content_type.second());
+        ASSERT_EQ(seq_type.content_type().kind(), TypeKind::INT_16_TYPE);
+        ASSERT_EQ(seq_type.bounds(), 0);
+    }
 
     ASSERT_TRUE(root.has_submodule("ModuleA"));
     const Module& mod_A = root["ModuleA"];
@@ -177,6 +190,7 @@ TEST (IDLGenerator, roundtrip)
             string my_string_array[VALUE_4];
             sequence<sequence<boolean, 5>, 3> my_nested_bool_seq5_3;
             int64 my_int64_nested_array[5][4];
+            map<RootEnum, sequence<int16>> my_map;
         };
 
         module ModuleA

--- a/test/unitary/xtypes/alias_type.cpp
+++ b/test/unitary/xtypes/alias_type.cpp
@@ -36,8 +36,8 @@ TEST (AliasType, alias_casting)
 {
     AliasType at(StringType(100), "str100");
 
-    ASSERT_DEATH({ static_cast<const StructType&>(at); },
-        XTYPES_ASSERT_ERRMSG("Alias \\[" + at.name() + "\\] cannot be cast to the specified type"));
+    ASSERT_OR_EXCEPTION({ static_cast<const StructType&>(at); },
+        "Alias [str100] cannot be cast to the specified type");
 }
 
 TEST (AliasType, dynamic_alias_data)
@@ -52,8 +52,7 @@ TEST (AliasType, dynamic_alias_data)
     const DynamicType& dt = data["st0"].type();
     ASSERT_EQ(dt.kind(), TypeKind::FLOAT_32_TYPE);
     ASSERT_EQ(static_cast<float>(data["st0"]), PI);
-    ASSERT_DEATH({ data["st0"] = "This will fail"; },
-        XTYPES_ASSERT_ERRMSG("Expected type 'float'"));
+    ASSERT_OR_EXCEPTION({ data["st0"] = "This will fail"; }, "Expected type 'float'");
 }
 
 TEST (AliasType, recursive_dynamic_alias_data)

--- a/test/unitary/xtypes/alias_type.cpp
+++ b/test/unitary/xtypes/alias_type.cpp
@@ -37,7 +37,7 @@ TEST (AliasType, alias_casting)
     AliasType at(StringType(100), "str100");
 
     ASSERT_OR_EXCEPTION({ static_cast<const StructType&>(at); },
-        "Alias [str100] cannot be cast to the specified type");
+        "cannot be cast to the specified type");
 }
 
 TEST (AliasType, dynamic_alias_data)

--- a/test/unitary/xtypes/collection_types.cpp
+++ b/test/unitary/xtypes/collection_types.cpp
@@ -531,7 +531,7 @@ TEST (CollectionTypes, map)
     EXPECT_EQ(10, d.size());
     EXPECT_EQ(10, d.bounds());
 
-    ASSERT_OR_EXCEPTION({DynamicData fails(d, m20_1);}, "Cannot copy data from type");
+    ASSERT_OR_EXCEPTION({DynamicData fails(d, m20_1);}, "Cannot copy data from different types");
 
     DynamicData dd(d, m20_2);
     EXPECT_EQ(10, dd.size());

--- a/test/unitary/xtypes/iterators.cpp
+++ b/test/unitary/xtypes/iterators.cpp
@@ -166,7 +166,6 @@ TEST (Iterators, dynamic_data)
             check_sum += elem[1].value<int32_t>();
         }
 
-        /*
         for (WritableDynamicDataRef&& elem : map)
         {
             elem[1] = elem[1].value<int32_t>() * 2;
@@ -178,7 +177,6 @@ TEST (Iterators, dynamic_data)
             double_check_sum += elem[1].value<int32_t>();
         }
         ASSERT_EQ(check_sum * 2, double_check_sum);
-        */
     }
 
     //SECTION("StructType")

--- a/test/unitary/xtypes/iterators.cpp
+++ b/test/unitary/xtypes/iterators.cpp
@@ -166,6 +166,7 @@ TEST (Iterators, dynamic_data)
             check_sum += elem[1].value<int32_t>();
         }
 
+        /*
         for (WritableDynamicDataRef&& elem : map)
         {
             elem[1] = elem[1].value<int32_t>() * 2;
@@ -177,6 +178,7 @@ TEST (Iterators, dynamic_data)
             double_check_sum += elem[1].value<int32_t>();
         }
         ASSERT_EQ(check_sum * 2, double_check_sum);
+        */
     }
 
     //SECTION("StructType")


### PR DESCRIPTION
This PR adds the MapType to xtypes. Includes:
- PairType Implementation: Used as MapType's content.
- Instanceable hash method: Used for hashing map's key values.
- MapType Implementation.
- MapType Tests.
- MapType parser integration and test.
- MapType generator integration and roundtrip test.
- MapType example.
- MapType & PairType documentation.