### PR TITLE
Ref #7606. Fix generation of "typedef <ArrayType>" IDL sentences

### DIFF
--- a/include/xtypes/ArrayType.hpp
+++ b/include/xtypes/ArrayType.hpp
@@ -90,20 +90,6 @@ public:
     /// \returns The dimension.
     uint32_t dimension() const { return dimension_; }
 
-    std::vector<uint32_t> dimensions() const
-    {
-        std::vector<uint32_t> dimensions_;
-        dimensions_.push_back(dimension_);
-        DynamicType::Ptr inner(*content_);
-        while(inner->kind() == TypeKind::ARRAY_TYPE)
-        {
-            const ArrayType& inner_array = static_cast<const ArrayType&>(*inner);
-            dimensions_.push_back(inner_array.dimension_);
-            inner = *inner_array.content_;
-        }
-        return dimensions_;
-    }
-
     virtual size_t memory_size() const override
     {
         return dimension_ * content_type().memory_size();

--- a/include/xtypes/ArrayType.hpp
+++ b/include/xtypes/ArrayType.hpp
@@ -90,6 +90,20 @@ public:
     /// \returns The dimension.
     uint32_t dimension() const { return dimension_; }
 
+    std::vector<uint32_t> dimensions() const
+    {
+        std::vector<uint32_t> dimensions_;
+        dimensions_.push_back(dimension_);
+        DynamicType::Ptr inner(*content_);
+        while(inner->kind() == TypeKind::ARRAY_TYPE)
+        {
+            const ArrayType& inner_array = static_cast<const ArrayType&>(*inner);
+            dimensions_.push_back(inner_array.dimension_);
+            inner = *inner_array.content_;
+        }
+        return dimensions_;
+    }
+
     virtual size_t memory_size() const override
     {
         return dimension_ * content_type().memory_size();

--- a/test/unitary/parser/parser_test.cpp
+++ b/test/unitary/parser/parser_test.cpp
@@ -1159,12 +1159,14 @@ TEST(IDLParser, alias_test)
         typedef double longfloat;
         typedef longfloat lfloat;
         typedef lfloat lflt;
+        typedef uint8 ByteMultiArray[2][3];
         struct StructData
         {
             u32 st0;
             longfloat st1;
             lfloat st2;
             lflt st3;
+            ByteMultiArray st4;
         };
     )";
 
@@ -1176,22 +1178,26 @@ TEST(IDLParser, alias_test)
     EXPECT_TRUE(m_context.has_alias("longfloat"));
     EXPECT_TRUE(m_context.has_alias("lfloat"));
     EXPECT_TRUE(m_context.has_alias("lflt"));
+    EXPECT_TRUE(m_context.has_alias("ByteMultiArray"));
 
     const StructType& st = m_context.structure("StructData");
     const DynamicType& dst0 = st.member("st0").type();
     const DynamicType& dst1 = st.member("st1").type();
     const DynamicType& dst2 = st.member("st2").type();
     const DynamicType& dst3 = st.member("st3").type();
+    const DynamicType& dst4 = st.member("st4").type();
     EXPECT_EQ(dst0.kind(), TypeKind::ALIAS_TYPE);
     EXPECT_EQ(dst1.kind(), TypeKind::ALIAS_TYPE);
     EXPECT_EQ(dst2.kind(), TypeKind::ALIAS_TYPE);
     EXPECT_EQ(dst3.kind(), TypeKind::ALIAS_TYPE);
+    EXPECT_EQ(dst4.kind(), TypeKind::ALIAS_TYPE);
     EXPECT_EQ(static_cast<const AliasType&>(dst0).get().kind(), TypeKind::UINT_32_TYPE);
     EXPECT_EQ(static_cast<const AliasType&>(dst1).get().kind(), TypeKind::FLOAT_64_TYPE);
     EXPECT_EQ(static_cast<const AliasType&>(dst2).get().kind(), TypeKind::ALIAS_TYPE);
     EXPECT_EQ(static_cast<const AliasType&>(dst2).rget().kind(), TypeKind::FLOAT_64_TYPE);
     EXPECT_EQ(static_cast<const AliasType&>(dst3).get().kind(), TypeKind::ALIAS_TYPE);
     EXPECT_EQ(static_cast<const AliasType&>(dst3).rget().kind(), TypeKind::FLOAT_64_TYPE);
+    EXPECT_EQ(static_cast<const AliasType&>(dst4).get().kind(), TypeKind::ARRAY_TYPE);
 }
 
 TEST (IDLParser, union_tests)


### PR DESCRIPTION
AliasType referencing to an ArrayType were not correctly being generated by `idl::generate` tool. Two main features were added:
* Properly generation for these types: `typedef uint8 ByteArray[10]` (prior to this, it was `typedef _array_10_uint8 ByteArray`).
* Multidimensional ArrayType types are now properly generated into IDL code (`typedef uint8 ByteMultiArray[10][3]`). 