### PR TITLE
Refs #5798 Added current_case method to ease conversions.

### DIFF
--- a/include/xtypes/DynamicData.hpp
+++ b/include/xtypes/DynamicData.hpp
@@ -190,6 +190,16 @@ public:
         return ReadableDynamicDataRef(member.type(), instance_);
     }
 
+    /// \brief returns the current selected member of an UnionType.
+    /// \pre The DynamicData must represent an UnionType.
+    /// \return The current selected member.
+    const Member& current_case() const
+    {
+        xtypes_assert(type_.kind() == TypeKind::UNION_TYPE, "current_case is only available for UnionType.");
+        const UnionType& aggregation = static_cast<const UnionType&>(type_);
+        return aggregation.get_current_selection(instance_);
+    }
+
     /// \brief key access method by DynamicData.
     /// \param[in] data DynamicData representing a MapType key.
     /// \pre The DynamicData must represent a MapType.

--- a/include/xtypes/UnionType.hpp
+++ b/include/xtypes/UnionType.hpp
@@ -867,6 +867,14 @@ protected:
         return *active_member_;
     }
 
+    /// \brief This method allows to retrieve the current selected case member (const).
+    const Member& get_current_selection(
+            const uint8_t* instance) const
+    {
+        xtypes_assert(active_member_ != nullptr, "UnionType '" << name() << "' doesn't have a case member selected.");
+        return *active_member_;
+    }
+
     /// \brief This method destroys previous active member, if any, and constructs the new one,
     /// setting it as active.
     void activate_member(


### PR DESCRIPTION
While converting, we have access to the discriminator values, but retrieve the current active member wasn't trivial.

This PR adds a method to `DynamicData` to make it trivial :+1: 