### PR TITLE
Ref #7611. Add new IDL generation algorithm with dependency solving between types and modules.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -132,6 +132,7 @@ if(XTYPES_BUILD_TESTS)
         test/unitary/parser/module.cpp
         test/unitary/parser/parser_test.cpp)
     compile_test(${PROJECT_NAME}_idl_parser_roundtrip SOURCE test/unitary/parser/roundtrip.cpp)
+    compile_test(${PROJECT_NAME}_idl_generator_dependencies SOURCE test/unitary/generator/dependencies.cpp)
     # ...
 
     # Set test with label NoMemoryCheck

--- a/include/xtypes/DynamicType.hpp
+++ b/include/xtypes/DynamicType.hpp
@@ -327,6 +327,13 @@ public:
             return type_;
         }
 
+        /// \brief Get a non-const pointer of the internal managed DynamicType.
+        /// \returns A non-const pointer of the interal managed DynamicType
+        DynamicType* operator ->()
+        {
+            return const_cast<DynamicType*>(type_);
+        }
+
         /// \brief Returns a reference of the intenral managed DynamicType.
         /// \returns A reference of the internal managed DynamicType.
         const DynamicType& operator *() const

--- a/include/xtypes/UnionType.hpp
+++ b/include/xtypes/UnionType.hpp
@@ -157,16 +157,6 @@ public:
         return add_case_member(labels, Member(name, type), is_default);
     }
 
-    template<typename T>
-    UnionType& add_case_member(
-            const T& label,
-            const std::string& name,
-            const DynamicType& type,
-            bool is_default = false)
-    {
-        return add_case_member(std::vector<T>(1, label), Member(name, type), is_default);
-    }
-
     /// \brief Create a member in this union with a type as rvalue.
     /// \param[in] name Member name to create.
     /// \param[in] type Member type fo the member.

--- a/include/xtypes/UnionType.hpp
+++ b/include/xtypes/UnionType.hpp
@@ -157,6 +157,16 @@ public:
         return add_case_member(labels, Member(name, type), is_default);
     }
 
+    template<typename T>
+    UnionType& add_case_member(
+            const T& label,
+            const std::string& name,
+            const DynamicType& type,
+            bool is_default = false)
+    {
+        return add_case_member(std::vector<T>(1, label), Member(name, type), is_default);
+    }
+
     /// \brief Create a member in this union with a type as rvalue.
     /// \param[in] name Member name to create.
     /// \param[in] type Member type fo the member.

--- a/include/xtypes/idl/Module.hpp
+++ b/include/xtypes/idl/Module.hpp
@@ -74,9 +74,10 @@ public:
 
     void for_each_submodule(
             ModuleVisitor visitor,
+            const Module* module,
             bool recursive = true) const
     {
-        for (const auto& inner : this->inner_)
+        for (const auto& inner : module->inner_)
         {
             visitor(*inner.second.get());
             if (recursive)
@@ -86,11 +87,18 @@ public:
         }
     }
 
+    void for_each_submodule(
+            ModuleVisitor visitor,
+            bool recursive = true) const
+    {
+        for_each_submodule(visitor, this, recursive);
+    }
+
     void for_each(
             ModuleVisitor visitor) const
     {
         visitor(*this);
-        for_each_submodule(visitor);
+        for_each_submodule(visitor, this);
     }
 
     bool has_submodule(
@@ -156,14 +164,9 @@ public:
             count++;
         }
 
-        Module* outer = outer_;
-        while (outer != nullptr)
+        if (outer_ != nullptr)
         {
-            if (outer->has_symbol(ident, false))
-            {
-                count++;
-            }
-            outer = outer->outer_;
+            count += outer_->symbol_count(ident);
         }
         return count;
     }

--- a/include/xtypes/idl/Module.hpp
+++ b/include/xtypes/idl/Module.hpp
@@ -65,6 +65,28 @@ public:
         return inner_[submodule];
     }
 
+    using ModuleVisitor = std::function<void(const Module& mod)>;
+
+    void for_each_submodule(
+            ModuleVisitor visitor,
+            const bool recursive=true) const
+    {
+        for (const auto& inner : this->inner_)
+        {
+            visitor(*inner.second.get());
+            if (recursive)
+            {
+                for_each_submodule(visitor, inner.second.get());
+            }
+        }
+    }
+
+    void for_each(ModuleVisitor visitor) const
+    {
+        visitor(*this);
+        for_each_submodule(visitor);
+    }
+
     bool has_submodule(
             const std::string& submodule) const
     {

--- a/include/xtypes/idl/Type.hpp
+++ b/include/xtypes/idl/Type.hpp
@@ -64,6 +64,16 @@ public:
         return type_;
     }
 
+    const DynamicType& operator * () const
+    {
+        return *type_;
+    }
+
+    const DynamicType* operator -> () const
+    {
+        return type_.get();
+    }
+
 private:
 
     Type(

--- a/include/xtypes/idl/generator.hpp
+++ b/include/xtypes/idl/generator.hpp
@@ -42,7 +42,7 @@ namespace idl {
 namespace generator {
 
 inline std::string sequence_type_name(
-        const dependencytree::DependencyNode* node,
+        dependencytree::DependencyNode* node,
         const DynamicType& type)
 {
     assert(type.kind() == TypeKind::SEQUENCE_TYPE);
@@ -57,7 +57,7 @@ inline std::string sequence_type_name(
 }
 
 inline std::string map_type_name(
-        const dependencytree::DependencyNode* node,
+        dependencytree::DependencyNode* node,
         const DynamicType& type)
 {
     assert(type.kind() == TypeKind::MAP_TYPE);
@@ -88,7 +88,7 @@ inline std::vector<uint32_t> array_dimensions(
 }
 
 inline std::string array_member(
-        const dependencytree::DependencyNode* node,
+        dependencytree::DependencyNode* node,
         const Member& member)
 {
     assert(member.type().kind() == TypeKind::ARRAY_TYPE);
@@ -107,7 +107,7 @@ inline std::string array_member(
 }
 
 inline std::string type_scope(
-        const dependencytree::DependencyNode* node,
+        dependencytree::DependencyNode* node,
         const DynamicType& type)
 {
     if (node == nullptr)
@@ -115,17 +115,17 @@ inline std::string type_scope(
         return std::string();
     }
     using namespace dependencytree;
-    const std::shared_ptr<DependencyModule>& from = node->from();
+    DependencyModule* from = node->from();
 
     if (from->opts_for_dependency_setting(type) && !from->has_symbol(type.name(), false))
     {
-        const std::shared_ptr<DependencyModule> dep_mod = from->search_module_with_node(type.name());
+        const DependencyModule* dep_mod = from->search_module_with_node(type.name());
         return from->relative_scope(dep_mod);
     }
     return std::string();
 }
 
-inline std::string type_name(const dependencytree::DependencyNode* node, const DynamicType& type)
+inline std::string type_name(dependencytree::DependencyNode* node, const DynamicType& type)
 {
     static const std::map<TypeKind, std::string> mapping =
     {

--- a/include/xtypes/idl/generator_deptree.hpp
+++ b/include/xtypes/idl/generator_deptree.hpp
@@ -1,0 +1,930 @@
+/*
+ * Copyright 2020, Proyectos y Sistemas de Mantenimiento SL (eProsima).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+#ifndef EPROSIMA_XTYPES_IDL_GENERATOR_DEPENDENCYTREE_HPP_
+#define EPROSIMA_XTYPES_IDL_GENERATOR_DEPENDENCYTREE_HPP_
+
+#include <xtypes/Module.hpp>
+#include <xtypes/idl/generator.hpp>
+
+namespace eprosima {
+
+namespace xtypes {
+
+namespace idl {
+
+namespace generator {
+
+// Forward declarations from "generator.hpp". Allows user to just include
+// "idl/generator.hpp" and forget about this file.
+inline std::string aliase(const DynamicType& type, const std::string& name);
+
+inline std::string type_name(const DynamicType& type);
+
+inline std::string get_const_value(ReadableDynamicDataRef data);
+
+inline std::string enumeration32(const EnumerationType<uint32_t>& enumeration, size_t tabs = 0);
+
+inline std::string structure(const StructType& type, size_t tabs = 0);
+
+inline std::string generate_union(const UnionType& type, size_t tabs = 0);
+
+namespace dependencytree {
+
+/// \brief Alias given to some Module's content element (alias, struct, constant...).
+/// std::pair is used, as Module's contents are stored using std::map containers.
+using ModuleElement = std::pair<const std::string, DynamicType::Ptr>;
+
+class DependencyModule; // Forward declaration
+
+/// \brief Enumeration that describes the kind of a DependencyNode.
+/// This enumeration reflects all possible kinds for a Module's content element.
+enum class ModuleElementKind
+{
+    ALIAS,
+    CONST,
+    ENUM,
+    STRUCT,
+    UNION
+};
+
+/// \brief A class to set a hierarchy between Module's contents.
+/// It stores a list of references to it's hierarchically greater contents
+/// (e.g. those who need to be declared before this one), as well as a pointer
+/// to the DependencyModule needing this DependencyNode's existence for it
+/// to be written into an IDL file (if any).
+class DependencyNode
+{
+public:
+
+    using NodeRefSet = std::vector<std::reference_wrapper<DependencyNode>>;
+
+    /// \brief Construct a DependencyNode
+    /// \param[in] node A key, value pair representing some Module's content element
+    /// \param[in] kind Module's content element kind (rvalue)
+    DependencyNode(
+            const ModuleElement& node,
+            const ModuleElementKind&& kind)
+        : node_(node)
+        , kind_(std::move(kind))
+        , iterated_(false)
+        , child_module_(nullptr)
+    {}
+
+    /// \brief Check if this DependencyNode has been iterated.
+    /// "Iterated" means that its IDL representation has already been generated.
+    /// \returns A boolean value indicating if object has been iterated or not.
+    bool iterated() const
+    {
+        return iterated_;
+    }
+
+    /// \brief Name of the DependencyNode.
+    /// \returns Key of the ModuleElement pair.
+    const std::string& name() const
+    {
+        return node_.first;
+    }
+
+    /// \brief Type of the DependencyNode.
+    /// \returns Pointed type by the ModuleElement pair value.
+    const DynamicType& type() const
+    {
+        return *node_.second;
+    }
+
+    /// \brief Kind of the DependencyNode.
+    /// \returns The assigned ModuleElementKind enumeration value.
+    const ModuleElementKind& kind() const
+    {
+        return kind_;
+    }
+
+    /// \brief Ask the DependencyNode if it does have any ancestor.
+    /// An ancestor would be another DependencyNode to be declared prior
+    /// to this one during the IDL generation.
+    /// \returns A logic value indicating if this DependencyNode has ancestors.
+    bool has_ancestors() const
+    {
+        return !ancestors_.empty();
+    }
+
+    /// \brief Get some DependencyNode's ancestors.
+    /// \returns A reference this node's ancestors container.
+    const NodeRefSet& ancestors() const
+    {
+        return ancestors_;
+    }
+
+    /// \brief Set a nwe ancestor for this DependencyNode.
+    /// \pre New ancestor is not added if it already exists.
+    /// \param[in] ancestor New ancestor to be set.
+    void set_ancestor(DependencyNode& ancestor)
+    {
+        for (const auto& ancestor_ : ancestors_)
+        {
+            if (ancestor_.get() == ancestor)
+            {
+                return;
+            }
+        }
+        ancestors_.push_back(ancestor);
+    }
+
+    /// \brief Ask this DependencyNode if any module depends on its existence.
+    /// \returns A logic value indicating if a child DependencyModule has been set.
+    bool has_child_module() const
+    {
+        return child_module_ != nullptr;
+    }
+
+    /// \brief Ask this DependencyNode if its child module dependency is an specific one.
+    /// \param[in] child DependencyModule to be compared with the inner one.
+    /// \returns The boolean result of the comparison.
+    bool has_child_module(
+            const std::shared_ptr<DependencyModule>& child) const
+    {
+        return child_module_ == child;
+    }
+
+    /// \brief Get this node's child DependencyModule.
+    /// \returns A constant reference to the child module.
+    const std::shared_ptr<DependencyModule>& child_module() const
+    {
+        return child_module_;
+    }
+
+    /// \brief Set the child module pointer to an specific value.
+    /// \param[in] child_module DependencyModule to be set.
+    void set_child_module(
+            const std::shared_ptr<DependencyModule>& child_module)
+    {
+        child_module_ = child_module;
+    }
+
+    /// \brief Ask this DependencyNode if any module is required for it to exist.
+    /// \returns A logic value indicating if a parent DependencyModule has been set.
+    bool has_parent_module() const
+    {
+        return parent_module_ != nullptr;
+    }
+
+    /// \brief Get this node's parent DependencyModule.
+    /// \returns A constant reference to the parent module.
+    const std::shared_ptr<DependencyModule>& parent_module() const
+    {
+        return parent_module_;
+    }
+
+    /// \brief Set the parent module pointer to an specific value.
+    /// \param[in] parent_module DependencyModule to be set.
+    void set_parent_module(
+            const std::shared_ptr<DependencyModule>& parent_module)
+    {
+        parent_module_ = parent_module;
+    }
+
+    /// \brief Generates the corresponding IDL sentence for this node
+    /// \param[in] from_enum List of the module's constants created from enums.
+    /// Required to properly generate "const" IDL sentences.
+    /// \param[in] constants Reference to module's constants values.
+    /// Required to properly generate "const" IDL sentences.
+    /// \param[in] tabs Padding relative to module's scope.
+    /// \return the generated sentence for this DependencyNode object.
+    std::string generate_idl_sentence(
+            const std::vector<std::string>& from_enum,
+            const std::map<std::string, DynamicData>& constants,
+            unsigned int tabs)
+    {
+        using namespace generator;
+
+        std::stringstream ss;
+
+        if (iterated_)
+        {
+            return std::string();
+        }
+
+        switch(kind_)
+        {
+            case ModuleElementKind::ALIAS:
+            {
+                ss << aliase(static_cast<const AliasType&>(type()).get(), name());
+                break;
+            }
+            case ModuleElementKind::CONST:
+            {
+                for (const auto& pair : constants)
+                {
+                    if (pair.first == name() &&
+                        std::find(from_enum.begin(), from_enum.end(), name()) == from_enum.end())
+                        // Don't add as const the "fake" enumeration consts.
+                    {
+                        ss << std::string(4 * tabs, ' ') << "const " << type_name(pair.second.type())
+                           << " " << pair.first  << " = " << get_const_value(pair.second) << ";" << std::endl;
+                        break;
+                    }
+                }
+                break;
+            }
+            case ModuleElementKind::ENUM:
+            {
+                ss << enumeration32(static_cast<const EnumerationType<uint32_t>&>(type()), tabs);
+                break;
+            }
+            case ModuleElementKind::STRUCT:
+            {
+                ss << structure(static_cast<const StructType&>(type()), tabs);
+                break;
+            }
+            case ModuleElementKind::UNION:
+            {
+                ss << generate_union(static_cast<const UnionType&>(type()), tabs);
+                break;
+            }
+        }
+
+        iterated_ = true;
+
+        return ss.str();
+    }
+
+    /// \brief Equal comparison operator overload between two DependencyNode objects.
+    /// \param[in] other The DependencyNode object to be compared with.
+    /// \returns A logic value indicating whether the two DependencyNode objects are equal or not.
+    inline bool operator == (
+            const DependencyNode& other) const
+    {
+        return (node_ == other.node_ && kind_ == other.kind_);
+    }
+
+    /// \brief Not equal comparison operator overload between two DependencyNode objects.
+    /// \param[in] other The DependencyNode object to be compared with.
+    /// \returns A logic value indication whether the two DependencyNode objects are different or not.
+    inline bool operator != (
+            const DependencyNode& other) const
+    {
+        return !operator==(other);
+    }
+
+private:
+
+    const ModuleElement& node_;
+    const ModuleElementKind kind_;
+    bool iterated_;
+    NodeRefSet ancestors_;
+    std::shared_ptr<DependencyModule> child_module_;
+    std::shared_ptr<DependencyModule> parent_module_;
+};
+
+/// \brief Class to set and store hierarchical relationships between Module objects.
+class DependencyModule : public Module, public std::enable_shared_from_this<DependencyModule>
+{
+public:
+
+    using ModuleSet = std::vector<std::shared_ptr<DependencyModule>>;
+    using NodeSet = std::vector<DependencyNode>;
+
+    /// \brief Construct a new DependencyModule object.
+    /// \param[in] module The Module object from which this objects inherits.
+    /// \param[in] outer A pointer to its outer DependencyModule. Here, "outer" does not
+    /// mean a hierarchically precedent DependencyModule to be printed before this in the
+    /// generated IDL file, but is a pointer to this Module's outer scoped Module object;
+    /// e.g. "this" is a submodule of "outer" (same as with Module class outer_ pointer)
+    DependencyModule(
+            const Module& module,
+            const std::shared_ptr<DependencyModule>& outer)
+        : Module(module)
+        , d_outer_(outer)
+        ,iterated_(false)
+    {
+        create_dependency_set();
+    }
+
+    /// \brief Check out if this DependencyModule has already been iterated.
+    /// "Iterated" means that its IDL has been already generated (avoid duplicity).
+    /// \returns A boolean value indicating if its IDL has been generated or not.
+    bool iterated() const
+    {
+        return iterated_;
+    }
+
+    /// \brief Change a DependencyModule's iterated property.
+    /// \param[in] Boolean value to set this DependencyModule as iterated (or not).
+    void set_iterated(bool iterated)
+    {
+        iterated_ = iterated;
+    }
+
+    /// \brief Get this DependencyModule's DependencyNode set.
+    /// \returns A reference to the NodeSet.
+    const NodeSet& node_set() const
+    {
+        return node_set_;
+    }
+
+    /// \brief Check if all DependencyNode objects from NodeSet have been already iterated.
+    /// \returns Boolean value with the result of the request.
+    bool all_nodes_iterated()
+    {
+        for (const auto& node : node_set_)
+        {
+            if (!node.iterated())
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /// \brief Check if all DependencyModule inner modules have been already iterated.
+    /// \returns Boolean value with the result of the request.
+    bool all_inner_iterated()
+    {
+        for (const auto& inner : d_inner_)
+        {
+            if (!inner->iterated())
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /// \brief Check if a DependencyModule has an outer DependencyModule set.
+    /// \returns A boolean value with the requested information.
+    inline bool has_outer() const
+    {
+        return d_outer_ != nullptr;
+    }
+
+    /// \brief Get a reference to this DependencyModule's outer DependencyModule pointer.
+    /// \returns A pointer to the outer DependencyModule.
+    const std::shared_ptr<DependencyModule>& outer() const
+    {
+        return d_outer_;
+    }
+
+    /// \brief Check if this DependencyModule, or any one above its module's branch in the module tree,
+    /// matches with the one provided.
+    /// \param[in] outer The DependencyModule whose existance in outer scopes wants to be checked.
+    /// \returns Boolean value indicating if any outer DependencyModule in this branch matches the provided one.
+    bool has_outer(
+            const std::shared_ptr<DependencyModule>& outer) const
+    {
+        if (has_outer())
+        {
+            if (d_outer_ == outer)
+            {
+                return true;
+            }
+            return d_outer_->has_outer(outer);
+        }
+
+        return false;
+    }
+
+    /// \brief Get a pointer to the outermost scoped DependencyModule in the module tree.
+    /// returns The outermost DependencyModule in the tree.
+    std::shared_ptr<DependencyModule> outer_root()
+    {
+        if (has_outer())
+        {
+            return d_outer_->outer_root();
+        }
+
+        return shared_from_this();
+    }
+
+    using DepModulesPair = std::pair<std::shared_ptr<DependencyModule>,
+                                     std::shared_ptr<DependencyModule>>;
+
+    /// \brief Find common outer DependencyModule objects siblings between this one and another.
+    /// "Siblings" means that they have a common outer module. For example:
+    /// "root" module containing "a" and "b" as submodules; "c" is also a submodule of "a". Common outer
+    /// siblings of "c" and "b" are <a, b>.
+    /// \pre This DependencyModule object must not be root.
+    /// \param[in] dep DependencyModule to find a common outer with.
+    /// \returns A pair of sibling DependencyModules.
+    DepModulesPair find_outer_siblings(
+            const std::shared_ptr<DependencyModule>& dep)
+    {
+        xtypes_assert(has_outer(), "Cannot use 'find_common_outer()' in root node.");
+
+        const std::shared_ptr<DependencyModule>& inner_dep = d_outer_->has_inner(dep);
+
+        if (inner_dep != nullptr)
+        {
+            return DepModulesPair(shared_from_this(), inner_dep);
+        }
+        else
+        {
+            return d_outer_->find_outer_siblings(dep);
+        }
+    }
+
+    /// \brief Return immediate inner DependencyModules in the tree.
+    /// \returns A reference to this DependencyModule's inner vector.
+    const ModuleSet& inner() const
+    {
+        return d_inner_;
+    }
+
+    /// \brief Check if this DependencyModule has a certain module as inner.
+    /// If recursive flag is set, it will look through its whole subtree.
+    /// \param[in] module DependencyModule to search for.
+    /// \param[in] recurse Go deep through the whole level (default), or just one level
+    /// \returns Pointer to inner module which matches (or contains) the one provided as parameter.
+    const std::shared_ptr<DependencyModule> has_inner(
+            const std::shared_ptr<DependencyModule>& module,
+            bool recurse=true)
+    {
+        for (const auto& inner : d_inner_)
+        {
+            if (inner == module || (recurse && inner->has_inner(module)))
+            {
+                return inner;
+            }
+        }
+
+        return nullptr;
+    }
+
+    /// \brief Add an inner DependencyModule to the inner list.
+    /// \param[in] inner Reference to the new inner DependencyModule.
+    void set_inner(const std::shared_ptr<DependencyModule>& inner)
+    {
+        d_inner_.push_back(inner);
+    }
+
+    /// \brief Check if this DependencyModule has any ancestors.
+    /// returns Boolean result of the request.
+    bool has_ancestors() const
+    {
+        return !ancestors_.empty();
+    }
+
+    /// \brief Get a list of ancestors for this DependencyModule.
+    /// \returns A const reference to the ancestors container.
+    const ModuleSet& ancestors() const
+    {
+        return ancestors_;
+    }
+
+    /// \brief Add a new ancestor for this DependencyModule. The ancestor
+    /// will be added only if it didn't exist before.
+    /// param[in] ancestor New DependencyModule to be set as ancestor.
+    void set_ancestor(
+            const std::shared_ptr<DependencyModule>& ancestor)
+    {
+        if (std::find(ancestors_.begin(), ancestors_.end(), ancestor) == ancestors_.end())
+        {
+            ancestors_.push_back(ancestor);
+        }
+    }
+
+    /// \brief Set a hierarchical ancestor. This implies:
+    /// - Not adding as ancestor a DependencyModule which is an outer of this one.
+    /// - Searching for common outer siblings (read 'find_outer_siblings' doc).
+    /// \param[in] ancestor The DependencyModule to be set as ancestor.
+    void set_hierarchical_ancestor(
+            const std::shared_ptr<DependencyModule>& ancestor)
+    {
+        if (!has_outer(ancestor))
+        {
+            DepModulesPair mpair = find_outer_siblings(ancestor);
+            mpair.first->set_ancestor(mpair.second);
+        }
+    }
+
+    #define ADD_INTO_DEPENDENCY_SET(SET, KIND) \
+    {\
+        for (const auto& node : SET)\
+        {\
+            node_set_.emplace_back(std::move(DependencyNode(node, ModuleElementKind::KIND)));\
+        }\
+    }
+
+    /// \brief Create a DependencyNode set for this DependencyModule.
+    inline void create_dependency_set()
+    {
+        ADD_INTO_DEPENDENCY_SET(aliases_, ALIAS);
+        ADD_INTO_DEPENDENCY_SET(constants_types_, CONST);
+        ADD_INTO_DEPENDENCY_SET(enumerations_32_, ENUM);
+        ADD_INTO_DEPENDENCY_SET(structs_, STRUCT);
+        ADD_INTO_DEPENDENCY_SET(unions_, UNION);
+    }
+
+    /// \brief Given a DependencyNode's name, search for it through the DependencyModule tree.
+    /// \param[in] name Name of the DependencyNode to be found.
+    /// \param[in] from_search Reference to DependencyModule that triggered the search. It will
+    /// be set as a child DependencyModule of the found DependencyNode.
+    /// \param[in] from_root Start search from DependencyModule's tree root.
+    /// \returns A pointer to the found DependencyModule.
+    const std::shared_ptr<DependencyModule> search_module_with_node(
+            const std::string& name,
+            const std::shared_ptr<DependencyModule>& from_search,
+            bool from_root=true)
+    {
+        if (from_root)
+        {
+            return outer_root()->search_module_with_node(name, from_search, false);
+        }
+        else
+        {
+            for (auto& node : node_set_)
+            {
+                if (node.name() == name)
+                {
+                    node.set_child_module(from_search);
+                    return shared_from_this();
+                }
+            }
+
+            for (const auto& inner : d_inner_)
+            {
+                std::shared_ptr<DependencyModule> found;
+                found = inner->search_module_with_node(name, from_search, false);
+
+                if (found != nullptr)
+                {
+                    return found;
+                }
+            }
+        }
+
+        return nullptr;
+    }
+
+    /// \brief Set a dependency between two DependencyNodes.
+    /// \param[in] dependent The DependencyNode objects which depends on master.
+    /// \param[in] master Name of the DependencyNode to be found in the tree.
+    /// \param[in] dep_list A ModuleElement map to search within this DependencyModule.
+    /// before triggering search in the whole tree.
+    void set_dependency(
+            DependencyNode& dependent,
+            const std::string& master,
+            const std::map<std::string, DynamicType::Ptr>& dep_list)
+    {
+        if (dependent.name() == master) // Cannot add dependency to itself
+        {
+            return;
+        }
+
+        if (dep_list.find(master) != dep_list.end())
+        {
+            for (auto& node : node_set_)
+            {
+                if (node.name() == master)
+                {
+                    dependent.set_ancestor(node);
+                    break;
+                }
+            }
+        }
+        else
+        {
+            const std::shared_ptr<DependencyModule>&
+                dep_mod =search_module_with_node(master, shared_from_this());
+
+            xtypes_assert(dep_mod != nullptr,
+                "Could not find module containing dependency named '" << master << "'.");
+
+
+            // Check if found module is a submodule of this one
+            const std::shared_ptr<DependencyModule> is_submod = has_inner(dep_mod);
+
+            if (is_submod != nullptr)
+            {
+                dependent.set_parent_module(is_submod);
+            }
+            else
+            {
+                set_hierarchical_ancestor(dep_mod);
+            }
+        }
+    }
+
+    /// \brief Wrapper function to set dependency based on DynamicType object.
+    /// If the DynamicType does not opt for dependency setting (i.e. is constructed),
+    /// no dependency is set.
+    /// \param[in] node The dependent node to be set a dependency ancestor.
+    /// \param[in] type The DynamicType of the master DependencyNode.
+    /// \param[in] master Name of the master DependencyNode to be set as ancestor.
+    inline void set_dynamic_type_dependency(
+            DependencyNode& node,
+            const DynamicType& type,
+            const std::string& master)
+    {
+        if (type.is_constructed_type())
+        {
+            switch (type.kind())
+            {
+                case TypeKind::ALIAS_TYPE:
+                {
+                    set_dependency(node, master, aliases_);
+                    break;
+                }
+                case TypeKind::ENUMERATION_TYPE:
+                {
+                    set_dependency(node, master, enumerations_32_);
+                    break;
+                }
+                case TypeKind::STRUCTURE_TYPE:
+                {
+                    set_dependency(node, master, structs_);
+                    break;
+                }
+                case TypeKind::UNION_TYPE:
+                {
+                    set_dependency(node, master, unions_);
+                    break;
+                }
+            }
+        }
+    }
+
+    /// \brief Inspects a DependencyNode object and sets dependencies according to its kind.
+    /// \param[in] node The DependencyNode whose dependencies wants to be solved.
+    void set_node_dependencies(DependencyNode& node)
+    {
+        switch (node.kind())
+        {
+            case ModuleElementKind::ALIAS:
+            {
+                const AliasType& alias = static_cast<const AliasType&>(node.type());
+                set_dynamic_type_dependency(node, *alias, alias.name());
+                break;
+            }
+
+            case ModuleElementKind::CONST:
+            {
+                const DynamicType& const_type = node.type();
+                set_dynamic_type_dependency(node, const_type, const_type.name());
+                break;
+            }
+
+            case ModuleElementKind::ENUM:
+            {
+                const EnumerationType<uint32_t>& enum_type = static_cast<const EnumerationType<uint32_t>&>(node.type());
+                set_dynamic_type_dependency(node, enum_type, enum_type.name());
+                break;
+
+            }
+            case ModuleElementKind::STRUCT:
+            {
+                const StructType& structure = static_cast<const StructType&>(node.type());
+
+                structure.for_each([&](const DynamicType::TypeNode& tnode)
+                {
+                    const DynamicType& type = tnode.type();
+                    set_dynamic_type_dependency(node, type, type.name());
+                });
+                break;
+            }
+            case ModuleElementKind::UNION:
+            {
+                const UnionType& union_type = static_cast<const UnionType&>(node.type());
+                union_type.for_each([&](const DynamicType::TypeNode& tnode)
+                {
+                    const DynamicType& type = tnode.type();
+                    set_dynamic_type_dependency(node, type, type.name());
+                });
+                break;
+            }
+            default:
+            {
+                xtypes_assert(false, "Type '" << node.name() << "' does not opt for dependency setting.");
+            }
+        }
+    }
+
+    /// \brief Helper function to solve dependencies for all DependencyNodes in a DependencyModule.
+    void solve_dependency_tree()
+    {
+        for (auto& node : node_set_)
+        {
+            set_node_dependencies(node);
+        }
+    }
+
+    /// \brief Generate IDL sentence for the DependencyNode contents of this module.
+    /// \param[in] tabs Padding relative to module's scope.
+    /// \param[in] is_child If set, generate IDL sentence only for DependencyNode that has as child
+    /// the "is_child" DependencyModule reference.
+    /// \returns An string with the generated IDL.
+    std::string generate_idl_module(
+            unsigned int tabs=0,
+            const std::shared_ptr<DependencyModule>& is_child=nullptr)
+    {
+        std::stringstream ss;
+
+        for (auto& node : node_set_)
+        {
+            if (is_child != nullptr && !node.has_child_module(is_child))
+            {
+                continue;
+            }
+
+            if (node.has_ancestors())
+            {
+                for (const auto& ancestor : node.ancestors())
+                {
+                    std::stringstream ss_ancestor;
+                    ss_ancestor << ancestor.get().generate_idl_sentence(from_enum_, constants_, tabs);
+
+                    if (ss_ancestor.rdbuf()->in_avail())
+                    {
+                        ss << ss_ancestor.str();
+                        ss << std::endl;
+                    }
+                }
+            }
+
+            std::stringstream ss_node;
+            ss_node << node.generate_idl_sentence(from_enum_, constants_, tabs);
+
+            if (ss_node.rdbuf()->in_avail() &&
+                (!all_nodes_iterated() || (!d_inner_.empty() && !all_inner_iterated())))
+            {
+                ss_node << std::endl;
+            }
+
+            ss << ss_node.str();
+        }
+
+        return ss.str();
+    }
+
+private:
+
+    bool iterated_;
+    const std::shared_ptr<DependencyModule> d_outer_;
+    ModuleSet d_inner_;
+    ModuleSet ancestors_;
+    NodeSet node_set_;
+};
+
+/// \brief A class for setting a Module object dependencies properly and generating its IDL.
+class ModuleDependencyTree
+{
+public:
+
+    /// \brief Construct a new ModuleDependencyTree object.
+    /// \param[in] root Module whose dependencies wants to be solved.
+    ModuleDependencyTree(
+            const Module& root)
+    {
+        dep_root_ = create_module_dep_tree(root);
+        solve_dependency_tree(dep_root_);
+    }
+
+    /// \brief Create DependencyModule tree from root node.
+    /// \param[in] module Current position in the tree.
+    /// \param[in] outer DependencyModule to be set as outer during construction of
+    /// new DependencyModule objects.
+    /// \returns A pointer to the resulting DependencyModule for provided 'module' parameter.
+    std::shared_ptr<DependencyModule> create_module_dep_tree(
+            const Module& module,
+            const std::shared_ptr<DependencyModule>& outer=nullptr)
+    {
+        std::shared_ptr<DependencyModule> dep =
+            std::make_shared<DependencyModule>(DependencyModule(module, outer));
+
+        module.for_each_submodule([&](const Module& submod)
+        {
+            std::shared_ptr<DependencyModule> child = create_module_dep_tree(submod, dep);
+            dep->set_inner(child);
+        }, false);
+
+        return dep;
+    }
+
+    /// \brief Solve dependency tree between DependencyModule objects.
+    /// \param[in] dep_mod the DependencyModule whose dependencies wants to be solved.
+    void solve_dependency_tree(
+            const std::shared_ptr<DependencyModule>& dep_mod) const
+    {
+        dep_mod->solve_dependency_tree();
+
+        for (const auto& inner : dep_mod->inner())
+        {
+            this->solve_dependency_tree(inner);
+        }
+    }
+
+    /// \brief Generate IDL sentence for a given DependencyModule.
+    /// \param[in] dep_mod the DependencyModule whose IDL wants to be generated.
+    /// \param[in] tabs Padding relative to module's scope.
+    /// \returns A string representing IDL definition for the given module.
+    std::string generate_idl(
+            const std::shared_ptr<DependencyModule>& dep_mod,
+            unsigned int tabs=0) const
+    {
+        if (dep_mod->iterated())
+        {
+            return std::string();
+        }
+
+        bool root = dep_mod->name().empty();
+        std::stringstream ss;
+
+        // Generate DependencyModule ancestors first
+        if (dep_mod->has_ancestors())
+        {
+            for (const auto& ancestor : dep_mod->ancestors())
+            {
+                ss << dep_mod->generate_idl_module(root ? 0 : tabs, ancestor);
+                ss << generate_idl(ancestor, root ? 0 : tabs);
+            }
+        }
+
+        if (!root)
+        {
+            ss << std::string(4 * tabs, ' ') << "module " << dep_mod->name() << std::endl;
+            ss << std::string(4 * tabs, ' ') << "{" << std::endl;
+        }
+
+        for (const auto& node : dep_mod->node_set())
+        {
+            if (node.has_parent_module())
+            {
+                ss << generate_idl(node.parent_module(), root ? 0 : tabs + 1) << std::endl;
+            }
+        }
+
+        ss << dep_mod->generate_idl_module(root ? 0 : tabs + 1);
+
+        // Iterate over inner DependencyModule list
+        for (const auto& inner : dep_mod->inner())
+        {
+            ss << generate_idl(inner, root ? 0 : tabs + 1);
+
+            if (!dep_mod->all_inner_iterated())
+            {
+                ss << std::endl;
+            }
+        }
+
+        if (!root)
+        {
+            ss << std::string(4 * tabs, ' ') << "};" << std::endl;
+        }
+
+        dep_mod->set_iterated(true);
+
+        return ss.str();
+    }
+
+    /// \brief Helper method to generate IDL from root Module of this ModuleDependencyTree object.
+    /// \returns A string representing IDL definition for root Module.
+    inline std::string generate_idl() const
+    {
+        return generate_idl(dep_root_);
+    }
+
+private:
+
+    std::shared_ptr<DependencyModule> dep_root_;
+};
+
+/// \brief Helper function to generate an IDL from a Module.
+/// \param[in] module The Module whose IDL wants to be created.
+/// \returns An string containing IDL definition for the given Module.
+inline std::string idl_from_module(const Module& module)
+{
+    return ModuleDependencyTree(module).generate_idl();
+}
+
+} //namespace dependencytree
+/// \brief Helper function to generate an IDL from a Module.
+/// Keeps backwards compatibility with previous 'generator::module' method
+/// and abstracts the user about accessing dependencytree namespace.
+/// \param[in] module The module whose IDL wants to be created.
+/// \returns An string containing IDL definition for the given Module.
+inline std::string module(const Module& module)
+{
+    return dependencytree::idl_from_module(module);
+}
+} //namespace generator
+} //namespace idl
+} //namespace xtypes
+} //namespace eprosima
+
+#endif //EPROSIMA_XTYPES_IDL_GENERATOR_DEPENDENCYTREE_HPP_

--- a/include/xtypes/idl/generator_deptree.hpp
+++ b/include/xtypes/idl/generator_deptree.hpp
@@ -810,7 +810,7 @@ public:
             case ModuleElementKind::ALIAS:
             {
                 const AliasType& alias = static_cast<const AliasType&>(node.type());
-                set_dynamic_type_dependency(node, *alias, alias.name());
+                set_dynamic_type_dependency(node, *alias, alias->name());
                 break;
             }
 

--- a/include/xtypes/idl/generator_deptree.hpp
+++ b/include/xtypes/idl/generator_deptree.hpp
@@ -797,6 +797,11 @@ public:
             {
                 const StructType& structure = static_cast<const StructType&>(node.type());
 
+                if (structure.has_parent())
+                {
+                    set_dynamic_type_dependency(node, structure.parent(), structure.parent().name());
+                }
+
                 structure.for_each([&](const DynamicType::TypeNode& tnode)
                 {
                     const DynamicType& type = tnode.type();

--- a/test/unitary/generator/dependencies.cpp
+++ b/test/unitary/generator/dependencies.cpp
@@ -64,8 +64,10 @@ void generation_roundtrip_test(
     std::vector<std::string> labels = {"Disc_1", "Disc_2"};
     my_union.add_case_member(labels, Member("my_union_alias", my_bool_alias_alias));
     std::vector<uint32_t> test(my_union_enum.value("Disc_3"));
-    my_union.add_case_member(my_union_enum.value("Disc_3"), "my_union_float", primitive_type<float>());
-    my_union.add_case_member(my_union_enum.value("Disc_4"), "my_union_struct", my_struct, true);
+    my_union.add_case_member<uint32_t>({my_union_enum.value("Disc_3")},
+                                       Member("my_union_float", primitive_type<float>()));
+    my_union.add_case_member<uint32_t>({my_union_enum.value("Disc_4")},
+                                       Member("my_union_struct", my_struct), true);
 
     for (const auto& pair : module_elements)
     {

--- a/test/unitary/generator/dependencies.cpp
+++ b/test/unitary/generator/dependencies.cpp
@@ -14,7 +14,6 @@
 
 #include <gtest/gtest.h>
 #include <xtypes/idl/idl.hpp>
-#include <boost/tokenizer.hpp>
 #include <iostream>
 
 using namespace eprosima::xtypes;

--- a/test/unitary/generator/dependencies.cpp
+++ b/test/unitary/generator/dependencies.cpp
@@ -21,14 +21,14 @@ using namespace eprosima::xtypes;
 void generation_roundtrip_test(
         const std::vector<std::pair<std::string, std::string>>& module_elements)
 {
-    Module root;
-    Module& mod_A = root.create_submodule("A");
-    Module& mod_B = root.create_submodule("B");
-    Module& mod_AB = mod_A.create_submodule("B");
-    Module& mod_AC = mod_A.create_submodule("C");
-    Module& mod_ABA = mod_AB.create_submodule("A");
+    idl::Module root;
+    idl::Module& mod_A = root.create_submodule("A");
+    idl::Module& mod_B = root.create_submodule("B");
+    idl::Module& mod_AB = mod_A.create_submodule("B");
+    idl::Module& mod_AC = mod_A.create_submodule("C");
+    idl::Module& mod_ABA = mod_AB.create_submodule("A");
 
-    const std::map<const std::string, Module&> modules = {
+    const std::map<const std::string, idl::Module&> modules = {
         {"A",       mod_A  },
         {"B",       mod_B  },
         {"A::B",    mod_AB },
@@ -71,7 +71,7 @@ void generation_roundtrip_test(
     {
         const std::string& submodule = pair.first;
 
-        Module* module = &root;
+        idl::Module* module = &root;
         if (!submodule.empty())
         {
             ASSERT_TRUE(modules.count(submodule));
@@ -126,17 +126,17 @@ void generation_roundtrip_test(
     idl::Context context = idl::parse(gen_idl);
     ASSERT_TRUE(context.success);
 
-    Module& root_gen = context.module();
+    idl::Module& root_gen = context.module();
     ASSERT_TRUE(root_gen.has_submodule("A"));
-    Module& modA_gen = root_gen["A"];
+    idl::Module& modA_gen = root_gen["A"];
     ASSERT_TRUE(modA_gen.has_submodule("B"));
-    Module& modAB_gen = modA_gen["B"];
+    idl::Module& modAB_gen = modA_gen["B"];
     ASSERT_TRUE(modA_gen.has_submodule("C"));
-    Module& modAC_gen = modA_gen["C"];
+    idl::Module& modAC_gen = modA_gen["C"];
     ASSERT_TRUE(modAB_gen.has_submodule("A"));
-    Module& modABA_gen = modAB_gen["A"];
+    idl::Module& modABA_gen = modAB_gen["A"];
     ASSERT_TRUE(root_gen.has_submodule("B"));
-    Module& modB_gen = root_gen["B"];
+    idl::Module& modB_gen = root_gen["B"];
 
     for (const auto& pair : module_elements)
     {

--- a/test/unitary/generator/dependencies.cpp
+++ b/test/unitary/generator/dependencies.cpp
@@ -1,0 +1,232 @@
+// Copyright 2020 Proyectos y Sistemas de Mantenimiento SL (eProsima).
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gtest/gtest.h>
+#include <xtypes/idl/idl.hpp>
+#include <boost/tokenizer.hpp>
+#include <iostream>
+
+using namespace eprosima::xtypes;
+
+void generation_roundtrip_test(
+        const std::vector<std::pair<std::string, std::string>>& module_elements)
+{
+    Module root;
+    Module& mod_A = root.create_submodule("A");
+    Module& mod_B = root.create_submodule("B");
+    Module& mod_AB = mod_A.create_submodule("B");
+    Module& mod_AC = mod_A.create_submodule("C");
+    Module& mod_ABA = mod_AB.create_submodule("A");
+
+    const std::map<const std::string, Module&> modules = {
+        {"A",       mod_A  },
+        {"B",       mod_B  },
+        {"A::B",    mod_AB },
+        {"A::C",    mod_AC },
+        {"A::B::A", mod_ABA}
+    };
+
+    EnumerationType<uint32_t> my_enum("MyEnum");
+    my_enum.add_enumerator("A", 0);
+    my_enum.add_enumerator("B", 1);
+    my_enum.add_enumerator("C", 2);
+
+    DynamicData my_enum_data(my_enum);
+    my_enum_data = my_enum.value("B");
+
+    EnumerationType<uint32_t> my_union_enum("MyDiscriminatorEnum");
+    my_union_enum.add_enumerator("Disc_1", 1);
+    my_union_enum.add_enumerator("Disc_2", 2);
+    my_union_enum.add_enumerator("Disc_3", 5);
+    my_union_enum.add_enumerator("Disc_4", 7);
+
+    AliasType my_bool_alias(primitive_type<bool>(), "MyBoolAlias");
+    AliasType my_bool_alias_alias(my_bool_alias, "MyBoolAliasAlias");
+
+    StructType my_struct("MyStruct");
+    my_struct.add_member(Member("ms0", primitive_type<uint16_t>()));
+    my_struct.add_member("ms1", my_enum);
+
+    StructType my_child_struct("MyChildStruct", &my_struct);
+    my_child_struct.add_member("mcs0", StringType(20));
+
+    UnionType my_union("MyUnion", my_union_enum);
+    std::vector<std::string> labels = {"Disc_1", "Disc_2"};
+    my_union.add_case_member(labels, Member("my_union_alias", my_bool_alias_alias));
+    std::vector<uint32_t> test(my_union_enum.value("Disc_3"));
+    my_union.add_case_member(my_union_enum.value("Disc_3"), "my_union_float", primitive_type<float>());
+    my_union.add_case_member(my_union_enum.value("Disc_4"), "my_union_struct", my_struct, true);
+
+    for (const auto& pair : module_elements)
+    {
+        const std::string& submodule = pair.first;
+
+        Module* module = &root;
+        if (!submodule.empty())
+        {
+            ASSERT_TRUE(modules.count(submodule));
+            module = &modules.at(submodule);
+        }
+
+        const std::string& type_name = pair.second;
+        if (type_name == "MyEnum")
+        {
+            module->enum_32(std::move(my_enum));
+        }
+        else if (type_name == "MyDiscriminatorEnum")
+        {
+            module->enum_32(std::move(my_union_enum));
+        }
+        else if (type_name == "MyEnumConst")
+        {
+            module->create_constant("MyEnumConst", my_enum_data);
+        }
+        else if (type_name == "MyBoolAlias")
+        {
+            module->add_alias(my_bool_alias);
+        }
+        else if (type_name == "MyBoolAliasAlias")
+        {
+            module->add_alias(my_bool_alias_alias);
+        }
+        else if (type_name == "MyStruct")
+        {
+            module->structure(my_struct);
+        }
+        else if (type_name == "MyChildStruct")
+        {
+            module->structure(my_child_struct);
+        }
+        else if (type_name == "MyUnion")
+        {
+            module->union_switch(my_union);
+        }
+        else
+        {
+            xtypes_assert(false, "Undeclared type: '" << type_name << "'.");
+        }
+    }
+
+    std::string gen_idl = idl::generate(root);
+    // Debug
+    // std::cout << "===========================================" << std::endl \
+              << gen_idl \
+              << "===========================================" << std::endl;
+    //Parse again and check if it went as expected
+    idl::Context context = idl::parse(gen_idl);
+    ASSERT_TRUE(context.success);
+
+    Module& root_gen = context.module();
+    ASSERT_TRUE(root_gen.has_submodule("A"));
+    Module& modA_gen = root_gen["A"];
+    ASSERT_TRUE(modA_gen.has_submodule("B"));
+    Module& modAB_gen = modA_gen["B"];
+    ASSERT_TRUE(modA_gen.has_submodule("C"));
+    Module& modAC_gen = modA_gen["C"];
+    ASSERT_TRUE(modAB_gen.has_submodule("A"));
+    Module& modABA_gen = modAB_gen["A"];
+    ASSERT_TRUE(root_gen.has_submodule("B"));
+    Module& modB_gen = root_gen["B"];
+
+    for (const auto& pair : module_elements)
+    {
+        const std::string& submodule = pair.first;
+
+        if (submodule == "")
+        {
+            ASSERT_TRUE(root_gen.has_symbol(pair.second));
+        } else if (submodule == "A")
+        {
+            ASSERT_TRUE(modA_gen.has_symbol(pair.second));
+        } else if (submodule == "B")
+        {
+            ASSERT_TRUE(modB_gen.has_symbol(pair.second));
+        } else if (submodule == "A::B")
+        {
+            ASSERT_TRUE(modAB_gen.has_symbol(pair.second));
+        } else if (submodule == "A::C")
+        {
+            ASSERT_TRUE(modAC_gen.has_symbol(pair.second));
+        } else if (submodule == "A::B::A")
+        {
+            ASSERT_TRUE(modABA_gen.has_symbol(pair.second));
+        } else
+        {
+            xtypes_assert(false, "Unknown module: '" << submodule << "'.");
+        }
+    }
+}
+
+TEST (IDLGenerator, dependencies)
+{
+    const std::vector<std::pair<std::string, std::string>> test1 =
+    {
+        {"",        "MyUnion"            },
+        {"",        "MyChildStruct"      },
+        {"",        "MyBoolAliasAlias"   },
+        {"A::B",    "MyEnumConst"        },
+        {"A::C",    "MyBoolAlias"        },
+        {"A::C",    "MyDiscriminatorEnum"},
+        {"A::B::A", "MyEnum"             },
+        {"B",       "MyStruct"           },
+    };
+    generation_roundtrip_test(test1);
+
+    const std::vector<std::pair<std::string, std::string>> test2 =
+    {
+        {"",        "MyEnum"             },
+        {"",        "MyUnion"            },
+        {"",        "MyEnumConst"        },
+        {"",        "MyBoolAliasAlias"   },
+        {"A",       "MyChildStruct"      },
+        {"A::C",    "MyBoolAlias"        },
+        {"A::B::A", "MyStruct"           },
+        {"B",       "MyDiscriminatorEnum"},
+    };
+    generation_roundtrip_test(test2);
+
+    const std::vector<std::pair<std::string, std::string>> test3 =
+    {
+        {"",        "MyStruct"           },
+        {"",        "MyEnumConst"        },
+        {"",        "MyBoolAliasAlias"   },
+        {"",        "MyDiscriminatorEnum"},
+        {"A::C",    "MyEnum"             },
+        {"A::B::A", "MyBoolAlias"        },
+        {"B",       "MyUnion"            },
+        {"B",       "MyChildStruct"      },
+    };
+    generation_roundtrip_test(test3);
+
+    // This test contains circular dependencies, hence it will fail until forward declarations are supported.
+    // TODO: uncomment once FW_DECL feature is implemented.
+    /*const std::vector<std::pair<std::string, std::string>> test4 =
+    {
+        {"B",       "MyStruct"           },
+        {"",        "MyEnumConst"        },
+        {"A::B::A", "MyBoolAliasAlias"   },
+        {"A",       "MyDiscriminatorEnum"},
+        {"A::C",    "MyEnum"             },
+        {"",        "MyBoolAlias"        },
+        {"B",       "MyUnion"            },
+        {"A",       "MyChildStruct"      },
+    };
+    generation_roundtrip_test(test4);*/
+}
+
+int main(int argc, char** argv)
+{
+    testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}

--- a/test/unitary/xtypes/alias_type.cpp
+++ b/test/unitary/xtypes/alias_type.cpp
@@ -104,8 +104,8 @@ TEST (AliasType, alias_idl_generate)
 
     std::string gen_idl = idl::generate(m);
     std::stringstream expected_idl;
-    expected_idl << "typedef utf8string u8str;" << std::endl << std::endl;
     expected_idl << "typedef wstring utf8string;" << std::endl << std::endl;
+    expected_idl << "typedef utf8string u8str;" << std::endl << std::endl;
     expected_idl << "struct StructData" << std::endl;
     expected_idl << "{" << std::endl;
     expected_idl << "    utf8string st0;" << std::endl;

--- a/test/unitary/xtypes/alias_type.cpp
+++ b/test/unitary/xtypes/alias_type.cpp
@@ -104,8 +104,8 @@ TEST (AliasType, alias_idl_generate)
 
     std::string gen_idl = idl::generate(m);
     std::stringstream expected_idl;
-    expected_idl << "typedef utf8string u8str;" << std::endl;
-    expected_idl << "typedef wstring utf8string;" << std::endl;
+    expected_idl << "typedef utf8string u8str;" << std::endl << std::endl;
+    expected_idl << "typedef wstring utf8string;" << std::endl << std::endl;
     expected_idl << "struct StructData" << std::endl;
     expected_idl << "{" << std::endl;
     expected_idl << "    utf8string st0;" << std::endl;


### PR DESCRIPTION
TODO before merge:
- [x] Add a reference to which Module a DynamicType belongs (task #7798). This will allow solving ambiguity problems (such as same kind and name DynamicType instances belonging to different modules). Generation algorithm will be indeed affected (possibly simplified) with this new feature. 