### PR TITLE
Refs #8050 Fix compatibility check with aliases. [8237]

### DIFF
--- a/include/xtypes/AggregationType.hpp
+++ b/include/xtypes/AggregationType.hpp
@@ -20,6 +20,7 @@
 
 #include <xtypes/DynamicType.hpp>
 #include <xtypes/Member.hpp>
+#include <xtypes/AliasType.hpp>
 
 #include <string>
 #include <map>

--- a/include/xtypes/ArrayType.hpp
+++ b/include/xtypes/ArrayType.hpp
@@ -205,6 +205,12 @@ public:
     virtual TypeConsistency is_compatible(
             const DynamicType& other) const override
     {
+        if (other.kind() == TypeKind::ALIAS_TYPE)
+        {
+            const AliasType& other_alias = static_cast<const AliasType&>(other);
+            return is_compatible(other_alias.rget());
+        }
+
         if(other.kind() != TypeKind::ARRAY_TYPE)
         {
             return TypeConsistency::NONE;

--- a/include/xtypes/CollectionType.hpp
+++ b/include/xtypes/CollectionType.hpp
@@ -19,6 +19,7 @@
 #define EPROSIMA_XTYPES_COLLECTION_TYPE_HPP_
 
 #include <xtypes/DynamicType.hpp>
+#include <xtypes/AliasType.hpp>
 
 namespace eprosima {
 namespace xtypes {

--- a/include/xtypes/EnumeratedType.hpp
+++ b/include/xtypes/EnumeratedType.hpp
@@ -82,6 +82,12 @@ public:
     virtual TypeConsistency is_compatible(
             const DynamicType& other) const override
     {
+        if (other.kind() == TypeKind::ALIAS_TYPE)
+        {
+            const AliasType& other_alias = static_cast<const AliasType&>(other);
+            return is_compatible(other_alias.rget());
+        }
+
         if (other.is_enumerated_type())
         {
             if (PrimitiveType<T>::memory_size() == other.memory_size())

--- a/include/xtypes/MapType.hpp
+++ b/include/xtypes/MapType.hpp
@@ -141,6 +141,12 @@ public:
     virtual TypeConsistency is_compatible(
             const DynamicType& other) const override
     {
+        if (other.kind() == TypeKind::ALIAS_TYPE)
+        {
+            const AliasType& other_alias = static_cast<const AliasType&>(other);
+            return is_compatible(other_alias.rget());
+        }
+
         if(other.kind() != TypeKind::MAP_TYPE)
         {
             return TypeConsistency::NONE;

--- a/include/xtypes/PairType.hpp
+++ b/include/xtypes/PairType.hpp
@@ -19,6 +19,7 @@
 #define EPROSIMA_XTYPES_PAIR_TYPE_HPP_
 
 #include <xtypes/DynamicType.hpp>
+#include <xtypes/AliasType.hpp>
 
 namespace eprosima {
 namespace xtypes {
@@ -131,6 +132,12 @@ public:
     virtual TypeConsistency is_compatible(
             const DynamicType& other) const override
     {
+        if (other.kind() == TypeKind::ALIAS_TYPE)
+        {
+            const AliasType& other_alias = static_cast<const AliasType&>(other);
+            return is_compatible(other_alias.rget());
+        }
+
         bool check = other.kind() == TypeKind::PAIR_TYPE;
 
         if (check)

--- a/include/xtypes/PrimitiveType.hpp
+++ b/include/xtypes/PrimitiveType.hpp
@@ -18,6 +18,7 @@
 #define EPROSIMA_XTYPES_PRIMITIVE_TYPE_HPP_
 
 #include <xtypes/DynamicType.hpp>
+#include <xtypes/AliasType.hpp>
 
 #include <cstring>
 
@@ -173,6 +174,12 @@ protected:
     virtual TypeConsistency is_compatible(
             const DynamicType& other) const override
     {
+        if (other.kind() == TypeKind::ALIAS_TYPE)
+        {
+            const AliasType& other_alias = static_cast<const AliasType&>(other);
+            return other_alias.is_compatible(*this);
+        }
+
         if(!other.is_primitive_type())
         {
             return TypeConsistency::NONE;

--- a/include/xtypes/SequenceType.hpp
+++ b/include/xtypes/SequenceType.hpp
@@ -128,6 +128,12 @@ public:
     virtual TypeConsistency is_compatible(
             const DynamicType& other) const override
     {
+        if (other.kind() == TypeKind::ALIAS_TYPE)
+        {
+            const AliasType& other_alias = static_cast<const AliasType&>(other);
+            return is_compatible(other_alias.rget());
+        }
+
         if(other.kind() != TypeKind::SEQUENCE_TYPE)
         {
             return TypeConsistency::NONE;

--- a/include/xtypes/StringType.hpp
+++ b/include/xtypes/StringType.hpp
@@ -103,6 +103,12 @@ public:
     virtual TypeConsistency is_compatible(
             const DynamicType& other) const override
     {
+        if (other.kind() == TypeKind::ALIAS_TYPE)
+        {
+            const AliasType& other_alias = static_cast<const AliasType&>(other);
+            return is_compatible(other_alias.rget());
+        }
+
         if(other.kind() != KIND)
         {
             return TypeConsistency::NONE;

--- a/include/xtypes/StructType.hpp
+++ b/include/xtypes/StructType.hpp
@@ -169,6 +169,12 @@ public:
     virtual TypeConsistency is_compatible(
             const DynamicType& other) const override
     {
+        if (other.kind() == TypeKind::ALIAS_TYPE)
+        {
+            const AliasType& other_alias = static_cast<const AliasType&>(other);
+            return is_compatible(other_alias.rget());
+        }
+
         if(other.kind() != TypeKind::STRUCTURE_TYPE)
         {
             return TypeConsistency::NONE;

--- a/include/xtypes/UnionType.hpp
+++ b/include/xtypes/UnionType.hpp
@@ -337,6 +337,12 @@ public:
     virtual TypeConsistency is_compatible(
             const DynamicType& other) const override
     {
+        if (other.kind() == TypeKind::ALIAS_TYPE)
+        {
+            const AliasType& other_alias = static_cast<const AliasType&>(other);
+            return is_compatible(other_alias.rget());
+        }
+
         if(other.kind() != TypeKind::UNION_TYPE)
         {
             return TypeConsistency::NONE;

--- a/test/unitary/xtypes/consistency.cpp
+++ b/test/unitary/xtypes/consistency.cpp
@@ -253,6 +253,7 @@ TEST (Consistency, testing_is_compatible_aliases)
     AliasType int32_alias_alias(int32_alias, "int32_t_alias");
     AliasType int32_alias_alias_alias(int32_alias_alias, "int32_t_alias_alias");
 
+    // One way
     EXPECT_EQ(int32_alias.is_compatible(primitive_type<int32_t>()), TypeConsistency::EQUALS);
     EXPECT_EQ(int32_alias.is_compatible(int32_alias_2), TypeConsistency::EQUALS);
     EXPECT_EQ(int32_alias.is_compatible(int32_alias_3), TypeConsistency::EQUALS);
@@ -266,6 +267,21 @@ TEST (Consistency, testing_is_compatible_aliases)
     EXPECT_EQ(int32_alias_alias_alias.is_compatible(int32_alias_2), TypeConsistency::EQUALS);
     EXPECT_EQ(int32_alias_alias_alias.is_compatible(int32_alias_3), TypeConsistency::EQUALS);
     EXPECT_EQ(int32_alias_alias_alias.is_compatible(int32_alias_alias), TypeConsistency::EQUALS);
+
+    // The other way
+    EXPECT_EQ(primitive_type<int32_t>().is_compatible(int32_alias), TypeConsistency::EQUALS);
+    EXPECT_EQ(int32_alias_2.is_compatible(int32_alias), TypeConsistency::EQUALS);
+    EXPECT_EQ(int32_alias_3.is_compatible(int32_alias), TypeConsistency::EQUALS);
+    EXPECT_EQ(int32_alias_alias.is_compatible(int32_alias), TypeConsistency::EQUALS);
+    EXPECT_EQ(int32_alias_alias_alias.is_compatible(int32_alias), TypeConsistency::EQUALS);
+    EXPECT_EQ(int32_alias.is_compatible(int32_alias_alias), TypeConsistency::EQUALS);
+    EXPECT_EQ(int32_alias_2.is_compatible(int32_alias_alias), TypeConsistency::EQUALS);
+    EXPECT_EQ(int32_alias_3.is_compatible(int32_alias_alias), TypeConsistency::EQUALS);
+    EXPECT_EQ(int32_alias_alias_alias.is_compatible(int32_alias_alias), TypeConsistency::EQUALS);
+    EXPECT_EQ(int32_alias.is_compatible(int32_alias_alias_alias), TypeConsistency::EQUALS);
+    EXPECT_EQ(int32_alias_2.is_compatible(int32_alias_alias_alias), TypeConsistency::EQUALS);
+    EXPECT_EQ(int32_alias_3.is_compatible(int32_alias_alias_alias), TypeConsistency::EQUALS);
+    EXPECT_EQ(int32_alias_alias.is_compatible(int32_alias_alias_alias), TypeConsistency::EQUALS);
 }
 
 TEST (Consistency , wstring_and_string_struct)


### PR DESCRIPTION
This PR fixes properly the aliases compatibility check when the alias is the `other` type.
Added a regression test too.