### PR TITLE
Fixing use of shared data in UnionType [8376]

### DIFF
--- a/include/xtypes/DynamicData.hpp
+++ b/include/xtypes/DynamicData.hpp
@@ -850,7 +850,7 @@ public:
     /// \pre The DynamicData must represent an UnionType.
     /// \pre The new discriminator value must be a valid label for the current selected value.
     void d(
-            size_t disc)
+            int64_t disc)
     {
         xtypes_assert(type_.kind() == TypeKind::UNION_TYPE, "discriminator is only available for UnionType.");
         UnionType& un = const_cast<UnionType&>(static_cast<const UnionType&>(type_));

--- a/test/unitary/parser/parser_test.cpp
+++ b/test/unitary/parser/parser_test.cpp
@@ -1295,7 +1295,7 @@ TEST (IDLParser, union_tests)
     data["wstr_b"] = L"Testing Wstring";
     EXPECT_EQ(data.d().value<uint32_t>(), 1);
 
-    EXPECT_EQ(data["union_c"].d().value<size_t>(), static_cast<size_t>(DEFAULT_UNION_LABEL));
+    EXPECT_EQ(data["union_c"].d().value<size_t>(), static_cast<size_t>(default_union_label(sizeof(uint64_t))));
     data["union_c"]["my_string"] = "Correct";
     data["union_c"]["my_float"] = 3.14f;
     EXPECT_EQ(data["union_c"].d().value<size_t>(), 2);
@@ -1485,7 +1485,8 @@ TEST (IDLParser, empty_struct)
 
 TEST (IDLParser, scoped_empty_struct)
 {
-    Context context = parse(R"(
+    Context context = parse(
+        R"(
         module a
         {
             module b

--- a/test/unitary/xtypes/union_type.cpp
+++ b/test/unitary/xtypes/union_type.cpp
@@ -40,7 +40,7 @@ TEST (UnionType, checks_and_access)
     ASSERT_OR_EXCEPTION({un.add_case_member<bool>({true}, Member("discriminator", primitive_type<uint32_t>()));},
             "is reserved");
 
-    ASSERT_OR_EXCEPTION({un.add_case_member<int64_t>({DEFAULT_UNION_LABEL}, Member("default_label",
+    ASSERT_OR_EXCEPTION({un.add_case_member<int64_t>({default_union_label(sizeof(bool))}, Member("default_label",
                          primitive_type<uint32_t>()));},
             "is reserved");
 
@@ -233,7 +233,7 @@ TEST (UnionType, default_behavior)
     union_type.add_case_member(labels, Member("a", primitive_type<uint32_t>()));
 
     DynamicData data(union_type);
-    EXPECT_EQ(data.d().value<uint32_t>(), static_cast<uint32_t>(DEFAULT_UNION_LABEL));
+    EXPECT_EQ(data.d().value<uint32_t>(), static_cast<uint32_t>(default_union_label(sizeof(uint32_t))));
     data["default"] = my_enum.value("C");
     EXPECT_EQ(data.get_member("default").value<uint32_t>(), 9);
 }


### PR DESCRIPTION
Until now all `DynamicData` of a `UnionType` use a shared variable `active_member` stored on the `DynamicType`. This is a bad implementation and provokes errors. This PR tries to fix this storing the information in the instance's buffer.
