### PR TITLE
[11619] Add package.xml

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
+  <name>xtypes</name>
+  <!-->There must be a release. Update version accordingly<-->
+  <version>0.1.0</version>
+  <description>
+    eProsima fast and lightweight C++17 header-only implementation of OMG DDS-XTYPES standard.
+  </description>
+  <!-->Update maintainer information<-->
+  <maintainer email="support@eprosima.com">eProsima</maintainer>
+  <license file="LICENSE">Apache 2.0</license>
+
+  <url type="website">https://www.eprosima.com/</url>
+  <url type="bugtracker">https://github.com/eProsima/xtypes/issues</url>
+  <url type="repository">https://github.com/eProsima/xtypes</url>
+
+  <buildtool_depend>cmake</buildtool_depend>
+
+  <doc_depend>doxygen</doc_depend>
+
+  <export>
+    <build_type>cmake</build_type>
+  </export>
+</package>


### PR DESCRIPTION
In order to use ROS tools to generate debian packages, a package.xml should be used. In order to bloom this package, it is important that the `--recursive` option has been used when cloning the repository. Otherwise the `peglib.h` header file is not installed and upstream packages will fail (for example `integration-service-core`)

Signed-off-by: JLBuenoLopez-eProsima <joseluisbueno@eprosima.com>