### PR TITLE
Move peglib to thirdparty

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 #####################################################################################
-#                             Top xtypes build system
+# Top xtypes build system
 #####################################################################################
-cmake_minimum_required(VERSION 3.1.0 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.5)
 
 project(xtypes
     VERSION "0.1.0"
@@ -12,6 +12,7 @@ option(XTYPES_BUILD_TESTS "Build tests." OFF)
 option(XTYPES_BUILD_EXAMPLES "Build examples." OFF)
 option(XTYPES_EXCEPTIONS "Enable xtypes exceptions in release (which are asserts in debug)." OFF)
 option(XTYPES_BUILD_TOOLS "Build tools." OFF)
+option(THIRDPARTY "Allow to download thidparty repository when needed." ON)
 
 if(XTYPES_EXCEPTIONS)
     #add_compile_definitions(XTYPES_EXCEPTIONS) #CMake 3.16
@@ -24,14 +25,27 @@ set(THREADS_PREFER_PTHREAD_FLAG ON)
 find_package(Threads REQUIRED)
 
 #####################################################################################
-#                                    Library
+# Load CMake modules
+#####################################################################################
+set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${PROJECT_SOURCE_DIR}/cmake/modules)
+include(${PROJECT_SOURCE_DIR}/cmake/common/eprosima_thirdparty_libraries.cmake)
+
+#####################################################################################
+# Thirdparty library
+#####################################################################################
+find_package(cpp-peglib REQUIRED)
+
+message(STATUS "Found peglib.h: ${cpp-peglib_INCLUDE_DIR}")
+
+#####################################################################################
+# Library
 #####################################################################################
 add_library(${PROJECT_NAME} INTERFACE)
 
 target_include_directories(${PROJECT_NAME}
     INTERFACE
         $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>
-        $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/thirdparty/cpp-peglib>
+        $<BUILD_INTERFACE:${cpp-peglib_INCLUDE_DIR}>        # Path to peglib.h
         $<INSTALL_INTERFACE:include>
         $<INSTALL_INTERFACE:thirdparty/cpp-peglib/include>
     )
@@ -42,7 +56,7 @@ target_compile_features(${PROJECT_NAME}
     )
 
 #####################################################################################
-#                                    Tools
+# Tools
 #####################################################################################
 macro(compile_tool)
     # Parse arguments
@@ -80,7 +94,7 @@ find_program(NODERED_EXECUTABLE NAMES node-red node-red@ PATH_SUFFIXES bin)
 
 if(XTYPES_BUILD_TOOLS OR NODERED_EXECUTABLE)
     compile_tool(${PROJECT_NAME}_idl_validator SOURCE tools/idl_validator.cpp)
-   
+
     if (NODERED_EXECUTABLE)
         file(WRITE $ENV{HOME}/idl_parser_path.txt "${PROJECT_BINARY_DIR}")
         message("${PROJECT_BINARY_DIR}")
@@ -89,7 +103,7 @@ if(XTYPES_BUILD_TOOLS OR NODERED_EXECUTABLE)
 endif()
 
 #####################################################################################
-#                                    Examples
+# Examples
 #####################################################################################
 macro(compile_example)
     # Parse arguments
@@ -132,7 +146,7 @@ if(XTYPES_BUILD_EXAMPLES)
 endif()
 
 #####################################################################################
-#                                      Tests
+# Tests
 #####################################################################################
 macro(compile_test)
     # Parse arguments
@@ -215,7 +229,7 @@ if(XTYPES_BUILD_TESTS)
 endif()
 
 #####################################################################################
-#                                   Installation
+# Installation
 #####################################################################################
 include(GNUInstallDirs)
 set(BIN_INSTALL_DIR     ${CMAKE_INSTALL_BINDIR}     CACHE PATH "Installation directory for binaries")
@@ -268,12 +282,10 @@ install(
     )
 
 install(
-    DIRECTORY
-        ${PROJECT_SOURCE_DIR}/thirdparty/cpp-peglib/
+    FILES
+        ${cpp-peglib_INCLUDE_DIR}/peglib.h
     DESTINATION
-        thirdparty/cpp-peglib/include
-    FILES_MATCHING
-        PATTERN "*.h"
+        ${INCLUDE_INSTALL_DIR}/thirdparty/cpp-peglib/include
     )
 
 install(

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 #####################################################################################
 # Top xtypes build system
 #####################################################################################
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.5 FATAL_ERROR)
 
 project(xtypes
     VERSION "0.1.0"
@@ -12,7 +12,7 @@ option(XTYPES_BUILD_TESTS "Build tests." OFF)
 option(XTYPES_BUILD_EXAMPLES "Build examples." OFF)
 option(XTYPES_EXCEPTIONS "Enable xtypes exceptions in release (which are asserts in debug)." OFF)
 option(XTYPES_BUILD_TOOLS "Build tools." OFF)
-option(THIRDPARTY "Allow to download thidparty repository when needed." ON)
+option(XTYPES_THIRDPARTY "Allow to download thidparty repository when needed." ON)
 
 if(XTYPES_EXCEPTIONS)
     #add_compile_definitions(XTYPES_EXCEPTIONS) #CMake 3.16
@@ -35,7 +35,7 @@ include(${PROJECT_SOURCE_DIR}/cmake/common/eprosima_thirdparty_libraries.cmake)
 #####################################################################################
 find_package(cpp-peglib REQUIRED)
 
-message(STATUS "Found peglib.h: ${cpp-peglib_INCLUDE_DIR}")
+message(STATUS "Found peglib.h in directory: ${cpp-peglib_INCLUDE_DIR}")
 
 #####################################################################################
 # Library
@@ -285,7 +285,7 @@ install(
     FILES
         ${cpp-peglib_INCLUDE_DIR}/peglib.h
     DESTINATION
-        # This could be ${INCLUDE_INSTALL_DIR}/ but is left like this so it does not break compatibilitys
+        # This could be ${INCLUDE_INSTALL_DIR}/ but is left like this so it does not break compatibility
         thirdparty/cpp-peglib/include
     )
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -285,7 +285,8 @@ install(
     FILES
         ${cpp-peglib_INCLUDE_DIR}/peglib.h
     DESTINATION
-        ${INCLUDE_INSTALL_DIR}/thirdparty/cpp-peglib/include
+        # This could be ${INCLUDE_INSTALL_DIR}/ but is left like this so it does not break compatibilitys
+        thirdparty/cpp-peglib/include
     )
 
 install(

--- a/README.md
+++ b/README.md
@@ -1,12 +1,9 @@
 # xtypes
 Fast and lightweight C++17 header-only implementation of [OMG DDS-XTYPES](https://www.omg.org/spec/DDS-XTypes) standard.
 
-To properly download this library, please consider cloning it using the `--recursive` options, as it includes the [cpp-peglib](https://github.com/yhirose/cpp-peglib) library as a submodule:
-
 ```bash
 git clone https://github.com/eProsima/xtypes.git --recursive
 ```
-
 
 ## Getting Started
 Given the following IDL,
@@ -60,8 +57,14 @@ int32_t my_value = data["c"]["a"];
   No memory penalty is introduced by using *eProsima xtypes* in relation to compiled types.
 - **Fast**: Accessing to data members is swift and quick.
 - **Header only library**: avoids the linking problems.
-- **No external dependency**: *eProsima xtypes*'s only dependencies are from *std*.
+- **No external dependency**: *eProsima xtypes*'s only dependencies are from *std*
+    (except cpp-peglib that will be downloaded in compilation time automatically in case it is not found in the system).
 - **Easy to use**: Comprehensive API and intuitive concepts.
+
+## Dependencies
+*eprosima xtypes* only dependency is `cpp-peglib`.
+This repository will be downloaded automatically if cmake option `THIRDPARTY` is set to `ON` (default value)
+or if `--recursive` argument is used to download this repository.
 
 ## Build
 *eprosima xtypes* is a header-only library: in order to use it you simply have to copy the files located in the include folder into your project and include them.

--- a/README.md
+++ b/README.md
@@ -62,8 +62,8 @@ int32_t my_value = data["c"]["a"];
 - **Easy to use**: Comprehensive API and intuitive concepts.
 
 ## Dependencies
-*eprosima xtypes* only dependency is `cpp-peglib`.
-This repository will be downloaded automatically if cmake option `THIRDPARTY` is set to `ON` (default value)
+*eProsima xtypes* only dependency is `cpp-peglib`.
+This repository will be downloaded automatically if CMake option `THIRDPARTY` is set to `ON` (default value)
 or if `--recursive` argument is used to download this repository.
 
 ## Build

--- a/cmake/common/eprosima_thirdparty_libraries.cmake
+++ b/cmake/common/eprosima_thirdparty_libraries.cmake
@@ -40,7 +40,7 @@ macro(eprosima_download_thirdparty package)
     set(ALLOWED_VALUES ON OFF FORCE)
 
     # Create the THIRDPARTY variable defaulting to OFF
-    set(THIRDPARTY ON CACHE STRING "Activate use of internal submodules.")
+    set(THIRDPARTY ${XTYPES_THIRDPARTY} CACHE STRING "Activate use of internal submodules.")
     # Define list of values GUI will offer for the variable
     set_property(CACHE THIRDPARTY PROPERTY STRINGS ON OFF FORCE)
     # Check that specified value is allowed

--- a/cmake/common/eprosima_thirdparty_libraries.cmake
+++ b/cmake/common/eprosima_thirdparty_libraries.cmake
@@ -1,0 +1,78 @@
+# Copyright 2021 Proyectos y Sistemas de Mantenimiento SL (eProsima).
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Macro to find cmake built thirdparty libraries.
+#
+# Arguments:
+#   :package: The name of the packge to find. Used for find_package(${package})
+#
+# Related CMake options:
+#   :THIRDPARTY: Activate the use of internal thirdparties [Defaults: ON].
+#        Possible values:
+#            * ON -> Use submodules only if package is not found elsewhere in the system.
+#            * OFF -> Do not use submodules.
+#            * FORCE -> Force the use submodules regarless of what is installed in the system.
+#   :THIRDPARTY_${package}: Specialization of THIRDPARTY for a specific ${package}. Same possibilities as THIRDPARTY.
+#        Unless specified otherwise, it has the same value as THIRDPARTY. Its value has preference over that of
+#        THIRDPARTY.
+#
+# The macro's procedure is as follows:
+#   If THIRDPARTY_${package} is ON, update the submodule in thirdparty folder
+#
+macro(eprosima_download_thirdparty package)
+    # Parse arguments.
+    set(options REQUIRED)
+    set(multiValueArgs OPTIONS)
+    cmake_parse_arguments(FIND "${options}" "" "${multiValueArgs}" ${ARGN})
+
+    # Define a list of allowed values for the options THIRDPARTY and THIRDPARTY_${package}
+    set(ALLOWED_VALUES ON OFF FORCE)
+
+    # Create the THIRDPARTY variable defaulting to OFF
+    set(THIRDPARTY ON CACHE STRING "Activate use of internal submodules.")
+    # Define list of values GUI will offer for the variable
+    set_property(CACHE THIRDPARTY PROPERTY STRINGS ON OFF FORCE)
+    # Check that specified value is allowed
+    if(NOT THIRDPARTY IN_LIST ALLOWED_VALUES)
+        message(FATAL_ERROR, "Wrong configuration of THIRDPARTY. Allowed values: ${ALLOWED_VALUES}")
+    endif()
+
+    # Create the THIRDPARTY_${package} variable defaulting to ${THIRDPARTY}. This way, we only need to check the value
+    # of THIRDPARTY_${package} from here on.
+    set(THIRDPARTY_${package} ${THIRDPARTY} CACHE STRING "Activate use of internal submodule ${package}.")
+    # Define list of values GUI will offer for the variable
+    set_property(CACHE THIRDPARTY_${package} PROPERTY STRINGS ON OFF FORCE)
+    # Check that specified value is allowed
+    if(NOT THIRDPARTY_${package} IN_LIST ALLOWED_VALUES)
+        message(FATAL_ERROR, "Wrong configuration of THIRDPARTY_${package}. Allowed values: ${ALLOWED_VALUES}")
+    endif()
+
+    option(THIRDPARTY_UPDATE "Activate the auto update of internal thirdparties" ON)
+
+    # Use thirdparty if THIRDPARTY_${package} is set to FORCE, or if the package is not found elsewhere and
+    # THIRDPARTY_${package} is set to ON.
+    if(THIRDPARTY_${package})
+        # Update submodule
+        message(STATUS "Updating submodule thirdparty/${package}")
+        execute_process(
+            COMMAND git submodule update --init "thirdparty/${package}"
+            WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
+            RESULT_VARIABLE EXECUTE_RESULT
+            )
+        # A result different than 0 means that the submodule could not be updated.
+        if(NOT EXECUTE_RESULT EQUAL 0)
+            message(WARNING "Cannot configure Git submodule ${package}")
+        endif()
+    endif()
+endmacro()

--- a/cmake/modules/Findcpp-peglib.cmake
+++ b/cmake/modules/Findcpp-peglib.cmake
@@ -1,0 +1,39 @@
+# Copyright 2021 Proyectos y Sistemas de Mantenimiento SL (eProsima).
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# THIRDPARTY
+
+message(STATUS "Module Find cpp-peglib")
+
+find_package(cpp-peglib CONFIG)
+if (NOT cpp-peglib_INCLUDE_DIR)
+    message(STATUS "Package cpp-peglib not found, looking for header")
+    find_path(cpp-peglib_INCLUDE_DIR NAMES peglib.h PATH_SUFFIXES include)
+endif()
+
+if (NOT cpp-peglib_INCLUDE_DIR)
+    message(STATUS "Path to peglib.h not found, looking in thirdparty")
+
+    # Using thirdparty macros
+    eprosima_download_thirdparty(cpp-peglib)
+    set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${PROJECT_SOURCE_DIR}/thirdparty/cpp-peglib)
+    find_path(cpp-peglib_INCLUDE_DIR NAMES peglib.h PATHS ${PROJECT_SOURCE_DIR}/thirdparty/cpp-peglib REQUIRED)
+endif()
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(cpp-peglib DEFAULT_MSG cpp-peglib_INCLUDE_DIR)
+
+mark_as_advanced(cpp-peglib_INCLUDE_DIR)
+
+message(STATUS "Module Find cpp-peglib end. Found peglib.h in ${cpp-peglib_INCLUDE_DIR}")

--- a/cmake/modules/Findcpp-peglib.cmake
+++ b/cmake/modules/Findcpp-peglib.cmake
@@ -12,9 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# THIRDPARTY
-
-message(STATUS "Module Find cpp-peglib")
+# XTYPES_THIRDPARTY
 
 find_package(cpp-peglib CONFIG)
 if (NOT cpp-peglib_INCLUDE_DIR)
@@ -35,5 +33,3 @@ include(FindPackageHandleStandardArgs)
 find_package_handle_standard_args(cpp-peglib DEFAULT_MSG cpp-peglib_INCLUDE_DIR)
 
 mark_as_advanced(cpp-peglib_INCLUDE_DIR)
-
-message(STATUS "Module Find cpp-peglib end. Found peglib.h in ${cpp-peglib_INCLUDE_DIR}")

--- a/colcon.pkg
+++ b/colcon.pkg
@@ -1,0 +1,5 @@
+{
+    "name": "xtypes",
+    "type": "cmake",
+    "dependencies" : ["cpp-peglib"]
+}

--- a/xtypes.repos
+++ b/xtypes.repos
@@ -1,0 +1,9 @@
+repositories:
+    cpp-peglib:
+        type: git
+        url: https://github.com/jparisu/cpp-peglib.git
+        version: b85d8c89cef68c80faf6d7ba3ffc048e58aa6f5b
+    xtypes:
+        type: git
+        url: https://github.com/eProsima/xtypes.git
+        version: main

--- a/xtypes.repos
+++ b/xtypes.repos
@@ -1,7 +1,7 @@
 repositories:
     cpp-peglib:
         type: git
-        url: https://github.com/jparisu/cpp-peglib.git
+        url: https://github.com/yhirose/cpp-peglib.git
         version: b85d8c89cef68c80faf6d7ba3ffc048e58aa6f5b
     xtypes:
         type: git


### PR DESCRIPTION
peglib was downloaded with `--recursive` argument to git when downloading the repo.

With this PR, peglib is a thirdparty in eprosima's thirdparty fashion way.
This is, if donwloaded with vcs, .repos will add this dependency.
In case this library is not in system neither in colcon workspace, cmake will downloaded it in compilation time in thirdparty and use it from there. 