### PR TITLE
fix: add limits include

### DIFF
--- a/include/xtypes/UnionType.hpp
+++ b/include/xtypes/UnionType.hpp
@@ -29,6 +29,7 @@
 #include <codecvt>
 #include <cwchar>
 #include <cuchar>
+#include <limits>
 
 namespace eprosima {
 namespace xtypes {


### PR DESCRIPTION
Hello,

I was unable to compile xtypes with GCC 11 on Ubuntu 22.04 without implicitly adding this include to `UnionTypes.hpp`.

Perhaps Ubuntu 22.04 needs to be added to the CI test systems.

```
--- stderr: is-core                             
In file included from /home/russ/work/is-workspace/install/xtypes/include/xtypes/xtypes.hpp:26,
                 from /home/russ/work/is-workspace/Integration-Service/core/include/is/core/Message.hpp:21,
                 from /home/russ/work/is-workspace/Integration-Service/core/include/is/core/runtime/FieldToString.hpp:22,
                 from /home/russ/work/is-workspace/Integration-Service/core/src/runtime/FieldToString.cpp:19:
/home/russ/work/is-workspace/install/xtypes/include/xtypes/UnionType.hpp: In function ‘constexpr int64_t eprosima::xtypes::default_union_label(size_t)’:
/home/russ/work/is-workspace/install/xtypes/include/xtypes/UnionType.hpp:45:17: error: ‘numeric_limits’ is not a member of ‘std’
   45 |     return std::numeric_limits<int64_t>::max() >> ((sizeof(int64_t) - type_size) * 8);
      |                 ^~~~~~~~~~~~~~
/home/russ/work/is-workspace/install/xtypes/include/xtypes/UnionType.hpp:45:39: error: expected primary-expression before ‘>’ token
   45 |     return std::numeric_limits<int64_t>::max() >> ((sizeof(int64_t) - type_size) * 8);
      |                                       ^
/home/russ/work/is-workspace/install/xtypes/include/xtypes/UnionType.hpp:45:42: error: ‘::max’ has not been declared; did you mean ‘std::max’?
   45 |     return std::numeric_limits<int64_t>::max() >> ((sizeof(int64_t) - type_size) * 8);
      |                                          ^~~
      |                                          std::max
In file included from /usr/include/c++/11/functional:65,
                 from /home/russ/work/is-workspace/install/xtypes/include/xtypes/Instanceable.hpp:23,
                 from /home/russ/work/is-workspace/install/xtypes/include/xtypes/DynamicType.hpp:22,
                 from /home/russ/work/is-workspace/install/xtypes/include/xtypes/CollectionType.hpp:21,
                 from /home/russ/work/is-workspace/install/xtypes/include/xtypes/ArrayType.hpp:21,
                 from /home/russ/work/is-workspace/install/xtypes/include/xtypes/xtypes.hpp:23,
                 from /home/russ/work/is-workspace/Integration-Service/core/include/is/core/Message.hpp:21,
                 from /home/russ/work/is-workspace/Integration-Service/core/include/is/core/runtime/FieldToString.hpp:22,
                 from /home/russ/work/is-workspace/Integration-Service/core/src/runtime/FieldToString.cpp:19:
/usr/include/c++/11/bits/stl_algo.h:3467:5: note: ‘std::max’ declared here
 3467 |     max(initializer_list<_Tp> __l, _Compare __comp)
      |     ^~~
In file included from /home/russ/work/is-workspace/install/xtypes/include/xtypes/xtypes.hpp:26,
                 from /home/russ/work/is-workspace/Integration-Service/core/include/is/core/Message.hpp:21,
                 from /home/russ/work/is-workspace/Integration-Service/core/include/is/core/runtime/StringTemplate.hpp:22,
                 from /home/russ/work/is-workspace/Integration-Service/core/src/runtime/StringTemplate.cpp:18:
/home/russ/work/is-workspace/install/xtypes/include/xtypes/UnionType.hpp: In function ‘constexpr int64_t eprosima::xtypes::default_union_label(size_t)’:
/home/russ/work/is-workspace/install/xtypes/include/xtypes/UnionType.hpp:45:17: error: ‘numeric_limits’ is not a member of ‘std’
   45 |     return std::numeric_limits<int64_t>::max() >> ((sizeof(int64_t) - type_size) * 8);
      |                 ^~~~~~~~~~~~~~
/home/russ/work/is-workspace/install/xtypes/include/xtypes/UnionType.hpp:45:39: error: expected primary-expression before ‘>’ token
   45 |     return std::numeric_limits<int64_t>::max() >> ((sizeof(int64_t) - type_size) * 8);
      |                                       ^
/home/russ/work/is-workspace/install/xtypes/include/xtypes/UnionType.hpp:45:42: error: ‘::max’ has not been declared; did you mean ‘std::max’?
   45 |     return std::numeric_limits<int64_t>::max() >> ((sizeof(int64_t) - type_size) * 8);
      |                                          ^~~
      |                                          std::max
In file included from /usr/include/c++/11/functional:65,
                 from /home/russ/work/is-workspace/install/xtypes/include/xtypes/Instanceable.hpp:23,
                 from /home/russ/work/is-workspace/install/xtypes/include/xtypes/DynamicType.hpp:22,
                 from /home/russ/work/is-workspace/install/xtypes/include/xtypes/CollectionType.hpp:21,
                 from /home/russ/work/is-workspace/install/xtypes/include/xtypes/ArrayType.hpp:21,
                 from /home/russ/work/is-workspace/install/xtypes/include/xtypes/xtypes.hpp:23,
                 from /home/russ/work/is-workspace/Integration-Service/core/include/is/core/Message.hpp:21,
                 from /home/russ/work/is-workspace/Integration-Service/core/include/is/core/runtime/StringTemplate.hpp:22,
                 from /home/russ/work/is-workspace/Integration-Service/core/src/runtime/StringTemplate.cpp:18:
/usr/include/c++/11/bits/stl_algo.h:3467:5: note: ‘std::max’ declared here
 3467 |     max(initializer_list<_Tp> __l, _Compare __comp)
      |     ^~~
In file included from /home/russ/work/is-workspace/install/xtypes/include/xtypes/xtypes.hpp:26,
                 from /home/russ/work/is-workspace/Integration-Service/core/include/is/core/Message.hpp:21,
                 from /home/russ/work/is-workspace/Integration-Service/core/include/is/core/runtime/FieldToString.hpp:22,
                 from /home/russ/work/is-workspace/Integration-Service/core/src/runtime/FieldToString.cpp:19:
/home/russ/work/is-workspace/install/xtypes/include/xtypes/UnionType.hpp: In function ‘constexpr int64_t eprosima::xtypes::shrink_label(T, size_t)’:
/home/russ/work/is-workspace/install/xtypes/include/xtypes/UnionType.hpp:53:48: error: ‘numeric_limits’ is not a member of ‘std’
   53 |     return static_cast<int64_t>(value) & (std::numeric_limits<uint64_t>::max()  >> ((sizeof(int64_t) - type_size) * 8));
      |                                                ^~~~~~~~~~~~~~
/home/russ/work/is-workspace/install/xtypes/include/xtypes/UnionType.hpp:53:71: error: expected primary-expression before ‘>’ token
   53 |     return static_cast<int64_t>(value) & (std::numeric_limits<uint64_t>::max()  >> ((sizeof(int64_t) - type_size) * 8));
      |                                                                       ^
/home/russ/work/is-workspace/install/xtypes/include/xtypes/UnionType.hpp:53:74: error: ‘::max’ has not been declared; did you mean ‘std::max’?
   53 |     return static_cast<int64_t>(value) & (std::numeric_limits<uint64_t>::max()  >> ((sizeof(int64_t) - type_size) * 8));
      |                                                                          ^~~
      |                                                                          std::max
In file included from /usr/include/c++/11/functional:65,
                 from /home/russ/work/is-workspace/install/xtypes/include/xtypes/Instanceable.hpp:23,
                 from /home/russ/work/is-workspace/install/xtypes/include/xtypes/DynamicType.hpp:22,
                 from /home/russ/work/is-workspace/install/xtypes/include/xtypes/CollectionType.hpp:21,
                 from /home/russ/work/is-workspace/install/xtypes/include/xtypes/ArrayType.hpp:21,
                 from /home/russ/work/is-workspace/install/xtypes/include/xtypes/xtypes.hpp:23,
                 from /home/russ/work/is-workspace/Integration-Service/core/include/is/core/Message.hpp:21,
                 from /home/russ/work/is-workspace/Integration-Service/core/include/is/core/runtime/FieldToString.hpp:22,
                 from /home/russ/work/is-workspace/Integration-Service/core/src/runtime/FieldToString.cpp:19:
/usr/include/c++/11/bits/stl_algo.h:3467:5: note: ‘std::max’ declared here
 3467 |     max(initializer_list<_Tp> __l, _Compare __comp)
      |     ^~~
In file included from /home/russ/work/is-workspace/install/xtypes/include/xtypes/xtypes.hpp:26,
                 from /home/russ/work/is-workspace/Integration-Service/core/include/is/core/Message.hpp:21,
                 from /home/russ/work/is-workspace/Integration-Service/core/include/is/core/runtime/StringTemplate.hpp:22,
                 from /home/russ/work/is-workspace/Integration-Service/core/src/runtime/StringTemplate.cpp:18:
/home/russ/work/is-workspace/install/xtypes/include/xtypes/UnionType.hpp: In function ‘constexpr int64_t eprosima::xtypes::shrink_label(T, size_t)’:
/home/russ/work/is-workspace/install/xtypes/include/xtypes/UnionType.hpp:53:48: error: ‘numeric_limits’ is not a member of ‘std’
   53 |     return static_cast<int64_t>(value) & (std::numeric_limits<uint64_t>::max()  >> ((sizeof(int64_t) - type_size) * 8));
      |                                                ^~~~~~~~~~~~~~
/home/russ/work/is-workspace/install/xtypes/include/xtypes/UnionType.hpp:53:71: error: expected primary-expression before ‘>’ token
   53 |     return static_cast<int64_t>(value) & (std::numeric_limits<uint64_t>::max()  >> ((sizeof(int64_t) - type_size) * 8));
      |                                                                       ^
/home/russ/work/is-workspace/install/xtypes/include/xtypes/UnionType.hpp:53:74: error: ‘::max’ has not been declared; did you mean ‘std::max’?
   53 |     return static_cast<int64_t>(value) & (std::numeric_limits<uint64_t>::max()  >> ((sizeof(int64_t) - type_size) * 8));
      |                                                                          ^~~
      |                                                                          std::max
In file included from /usr/include/c++/11/functional:65,
                 from /home/russ/work/is-workspace/install/xtypes/include/xtypes/Instanceable.hpp:23,
                 from /home/russ/work/is-workspace/install/xtypes/include/xtypes/DynamicType.hpp:22,
                 from /home/russ/work/is-workspace/install/xtypes/include/xtypes/CollectionType.hpp:21,
                 from /home/russ/work/is-workspace/install/xtypes/include/xtypes/ArrayType.hpp:21,
                 from /home/russ/work/is-workspace/install/xtypes/include/xtypes/xtypes.hpp:23,
                 from /home/russ/work/is-workspace/Integration-Service/core/include/is/core/Message.hpp:21,
                 from /home/russ/work/is-workspace/Integration-Service/core/include/is/core/runtime/StringTemplate.hpp:22,
                 from /home/russ/work/is-workspace/Integration-Service/core/src/runtime/StringTemplate.cpp:18:
/usr/include/c++/11/bits/stl_algo.h:3467:5: note: ‘std::max’ declared here
 3467 |     max(initializer_list<_Tp> __l, _Compare __comp)
      |     ^~~
In file included from /home/russ/work/is-workspace/install/xtypes/include/xtypes/xtypes.hpp:26,
                 from /home/russ/work/is-workspace/Integration-Service/core/include/is/core/Message.hpp:21,
                 from /home/russ/work/is-workspace/Integration-Service/core/include/is/systemhandle/SystemHandle.hpp:23,
                 from /home/russ/work/is-workspace/Integration-Service/core/include/is/systemhandle/RegisterSystem.hpp:22,
                 from /home/russ/work/is-workspace/Integration-Service/core/include/is/core/Config.hpp:22,
                 from /home/russ/work/is-workspace/Integration-Service/core/src/Config.cpp:19:
/home/russ/work/is-workspace/install/xtypes/include/xtypes/UnionType.hpp: In function ‘constexpr int64_t eprosima::xtypes::default_union_label(size_t)’:
/home/russ/work/is-workspace/install/xtypes/include/xtypes/UnionType.hpp:45:17: error: ‘numeric_limits’ is not a member of ‘std’
   45 |     return std::numeric_limits<int64_t>::max() >> ((sizeof(int64_t) - type_size) * 8);
      |                 ^~~~~~~~~~~~~~
/home/russ/work/is-workspace/install/xtypes/include/xtypes/UnionType.hpp:45:39: error: expected primary-expression before ‘>’ token
   45 |     return std::numeric_limits<int64_t>::max() >> ((sizeof(int64_t) - type_size) * 8);
      |                                       ^
/home/russ/work/is-workspace/install/xtypes/include/xtypes/UnionType.hpp:45:42: error: ‘::max’ has not been declared; did you mean ‘std::max’?
   45 |     return std::numeric_limits<int64_t>::max() >> ((sizeof(int64_t) - type_size) * 8);
      |                                          ^~~
      |                                          std::max
In file included from /usr/include/c++/11/functional:65,
                 from /home/russ/work/is-workspace/Integration-Service/core/include/is/systemhandle/SystemHandleFactory.hpp:23,
                 from /home/russ/work/is-workspace/Integration-Service/core/include/is/systemhandle/SystemHandle.hpp:22,
                 from /home/russ/work/is-workspace/Integration-Service/core/include/is/systemhandle/RegisterSystem.hpp:22,
                 from /home/russ/work/is-workspace/Integration-Service/core/include/is/core/Config.hpp:22,
                 from /home/russ/work/is-workspace/Integration-Service/core/src/Config.cpp:19:
/usr/include/c++/11/bits/stl_algo.h:3467:5: note: ‘std::max’ declared here
 3467 |     max(initializer_list<_Tp> __l, _Compare __comp)
      |     ^~~
In file included from /home/russ/work/is-workspace/install/xtypes/include/xtypes/xtypes.hpp:26,
                 from /home/russ/work/is-workspace/Integration-Service/core/include/is/core/Message.hpp:21,
                 from /home/russ/work/is-workspace/Integration-Service/core/include/is/systemhandle/SystemHandle.hpp:23,
                 from /home/russ/work/is-workspace/Integration-Service/core/include/is/systemhandle/RegisterSystem.hpp:22,
                 from /home/russ/work/is-workspace/Integration-Service/core/include/is/core/Config.hpp:22,
                 from /home/russ/work/is-workspace/Integration-Service/core/src/Config.cpp:19:
/home/russ/work/is-workspace/install/xtypes/include/xtypes/UnionType.hpp: In function ‘constexpr int64_t eprosima::xtypes::shrink_label(T, size_t)’:
/home/russ/work/is-workspace/install/xtypes/include/xtypes/UnionType.hpp:53:48: error: ‘numeric_limits’ is not a member of ‘std’
   53 |     return static_cast<int64_t>(value) & (std::numeric_limits<uint64_t>::max()  >> ((sizeof(int64_t) - type_size) * 8));
      |                                                ^~~~~~~~~~~~~~
/home/russ/work/is-workspace/install/xtypes/include/xtypes/UnionType.hpp:53:71: error: expected primary-expression before ‘>’ token
   53 |     return static_cast<int64_t>(value) & (std::numeric_limits<uint64_t>::max()  >> ((sizeof(int64_t) - type_size) * 8));
      |                                                                       ^
/home/russ/work/is-workspace/install/xtypes/include/xtypes/UnionType.hpp:53:74: error: ‘::max’ has not been declared; did you mean ‘std::max’?
   53 |     return static_cast<int64_t>(value) & (std::numeric_limits<uint64_t>::max()  >> ((sizeof(int64_t) - type_size) * 8));
      |                                                                          ^~~
      |                                                                          std::max
In file included from /usr/include/c++/11/functional:65,
                 from /home/russ/work/is-workspace/Integration-Service/core/include/is/systemhandle/SystemHandleFactory.hpp:23,
                 from /home/russ/work/is-workspace/Integration-Service/core/include/is/systemhandle/SystemHandle.hpp:22,
                 from /home/russ/work/is-workspace/Integration-Service/core/include/is/systemhandle/RegisterSystem.hpp:22,
                 from /home/russ/work/is-workspace/Integration-Service/core/include/is/core/Config.hpp:22,
                 from /home/russ/work/is-workspace/Integration-Service/core/src/Config.cpp:19:
/usr/include/c++/11/bits/stl_algo.h:3467:5: note: ‘std::max’ declared here
 3467 |     max(initializer_list<_Tp> __l, _Compare __comp)
      |     ^~~
In file included from /home/russ/work/is-workspace/install/xtypes/include/xtypes/xtypes.hpp:26,
                 from /home/russ/work/is-workspace/Integration-Service/core/include/is/core/Message.hpp:21,
                 from /home/russ/work/is-workspace/Integration-Service/core/include/is/systemhandle/SystemHandle.hpp:23,
                 from /home/russ/work/is-workspace/Integration-Service/core/include/is/systemhandle/RegisterSystem.hpp:22,
                 from /home/russ/work/is-workspace/Integration-Service/core/src/systemhandle/RegisterSystem.cpp:19:
/home/russ/work/is-workspace/install/xtypes/include/xtypes/UnionType.hpp: In function ‘constexpr int64_t eprosima::xtypes::default_union_label(size_t)’:
/home/russ/work/is-workspace/install/xtypes/include/xtypes/UnionType.hpp:45:17: error: ‘numeric_limits’ is not a member of ‘std’
   45 |     return std::numeric_limits<int64_t>::max() >> ((sizeof(int64_t) - type_size) * 8);
      |                 ^~~~~~~~~~~~~~
/home/russ/work/is-workspace/install/xtypes/include/xtypes/UnionType.hpp:45:39: error: expected primary-expression before ‘>’ token
   45 |     return std::numeric_limits<int64_t>::max() >> ((sizeof(int64_t) - type_size) * 8);
      |                                       ^
/home/russ/work/is-workspace/install/xtypes/include/xtypes/UnionType.hpp:45:42: error: ‘::max’ has not been declared; did you mean ‘std::max’?
   45 |     return std::numeric_limits<int64_t>::max() >> ((sizeof(int64_t) - type_size) * 8);
      |                                          ^~~
      |                                          std::max
In file included from /usr/include/c++/11/functional:65,
                 from /home/russ/work/is-workspace/Integration-Service/core/include/is/systemhandle/SystemHandleFactory.hpp:23,
                 from /home/russ/work/is-workspace/Integration-Service/core/include/is/systemhandle/SystemHandle.hpp:22,
                 from /home/russ/work/is-workspace/Integration-Service/core/include/is/systemhandle/RegisterSystem.hpp:22,
                 from /home/russ/work/is-workspace/Integration-Service/core/src/systemhandle/RegisterSystem.cpp:19:
/usr/include/c++/11/bits/stl_algo.h:3467:5: note: ‘std::max’ declared here
 3467 |     max(initializer_list<_Tp> __l, _Compare __comp)
      |     ^~~
In file included from /home/russ/work/is-workspace/install/xtypes/include/xtypes/xtypes.hpp:26,
                 from /home/russ/work/is-workspace/Integration-Service/core/include/is/core/Message.hpp:21,
                 from /home/russ/work/is-workspace/Integration-Service/core/include/is/systemhandle/SystemHandle.hpp:23,
                 from /home/russ/work/is-workspace/Integration-Service/core/include/is/systemhandle/RegisterSystem.hpp:22,
                 from /home/russ/work/is-workspace/Integration-Service/core/src/systemhandle/RegisterSystem.cpp:19:
/home/russ/work/is-workspace/install/xtypes/include/xtypes/UnionType.hpp: In function ‘constexpr int64_t eprosima::xtypes::shrink_label(T, size_t)’:
/home/russ/work/is-workspace/install/xtypes/include/xtypes/UnionType.hpp:53:48: error: ‘numeric_limits’ is not a member of ‘std’
   53 |     return static_cast<int64_t>(value) & (std::numeric_limits<uint64_t>::max()  >> ((sizeof(int64_t) - type_size) * 8));
      |                                                ^~~~~~~~~~~~~~
/home/russ/work/is-workspace/install/xtypes/include/xtypes/UnionType.hpp:53:71: error: expected primary-expression before ‘>’ token
   53 |     return static_cast<int64_t>(value) & (std::numeric_limits<uint64_t>::max()  >> ((sizeof(int64_t) - type_size) * 8));
      |                                                                       ^
/home/russ/work/is-workspace/install/xtypes/include/xtypes/UnionType.hpp:53:74: error: ‘::max’ has not been declared; did you mean ‘std::max’?
   53 |     return static_cast<int64_t>(value) & (std::numeric_limits<uint64_t>::max()  >> ((sizeof(int64_t) - type_size) * 8));
      |                                                                          ^~~
      |                                                                          std::max
In file included from /usr/include/c++/11/functional:65,
                 from /home/russ/work/is-workspace/Integration-Service/core/include/is/systemhandle/SystemHandleFactory.hpp:23,
                 from /home/russ/work/is-workspace/Integration-Service/core/include/is/systemhandle/SystemHandle.hpp:22,
                 from /home/russ/work/is-workspace/Integration-Service/core/include/is/systemhandle/RegisterSystem.hpp:22,
                 from /home/russ/work/is-workspace/Integration-Service/core/src/systemhandle/RegisterSystem.cpp:19:
/usr/include/c++/11/bits/stl_algo.h:3467:5: note: ‘std::max’ declared here
 3467 |     max(initializer_list<_Tp> __l, _Compare __comp)
      |     ^~~
gmake[2]: *** [CMakeFiles/is-core.dir/build.make:76: CMakeFiles/is-core.dir/src/runtime/FieldToString.cpp.o] Error 1
gmake[2]: *** Waiting for unfinished jobs....
gmake[2]: *** [CMakeFiles/is-core.dir/build.make:118: CMakeFiles/is-core.dir/src/runtime/StringTemplate.cpp.o] Error 1
gmake[2]: *** [CMakeFiles/is-core.dir/build.make:132: CMakeFiles/is-core.dir/src/systemhandle/RegisterSystem.cpp.o] Error 1
gmake[2]: *** [CMakeFiles/is-core.dir/build.make:160: CMakeFiles/is-core.dir/src/Config.cpp.o] Error 1
gmake[1]: *** [CMakeFiles/Makefile2:130: CMakeFiles/is-core.dir/all] Error 2
gmake: *** [Makefile:146: all] Error 2
---
Failed   <<< is-core [5.28s, exited with code 2]

Summary: 2 packages finished [5.62s]
  1 package failed: is-core
  1 package had stderr output: is-core
  6 packages not processed
```