### PR TITLE
C++20 compatability

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,7 +31,7 @@ add_library(${PROJECT_NAME} INTERFACE)
 
 # Download the cpp-peglib header file needed
 file(DOWNLOAD
-        https://raw.githubusercontent.com/yhirose/cpp-peglib/master/peglib.h
+        https://raw.githubusercontent.com/yhirose/cpp-peglib/v1.8.2/peglib.h
         ${PROJECT_SOURCE_DIR}/thirdparty/cpp-peglib/peglib.h
     )
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,7 +40,7 @@ target_include_directories(${PROJECT_NAME}
         $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>
         $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/thirdparty/cpp-peglib>
         $<INSTALL_INTERFACE:include>
-        $<INSTALL_INTERFACE:thirdparty/cpp-peglib/include>
+        # $<INSTALL_INTERFACE:thirdparty/cpp-peglib/include>
     )
 
 target_compile_features(${PROJECT_NAME}
@@ -231,12 +231,13 @@ set(LIB_INSTALL_DIR     ${CMAKE_INSTALL_LIBDIR}     CACHE PATH "Installation dir
 set(DATA_INSTALL_DIR    ${CMAKE_INSTALL_DATADIR}    CACHE PATH "Installation directory for data")
 
 include(CMakePackageConfigHelpers)
+string(REPLACE "/${CMAKE_LIBRARY_ARCHITECTURE}" "" CMAKE_INSTALL_LIBDIR_ARCHIND "${CMAKE_INSTALL_LIBDIR}")
 
 configure_package_config_file(
     ${PROJECT_SOURCE_DIR}/cmake/config.cmake.in
     ${PROJECT_BINARY_DIR}/cmake/config/${PROJECT_NAME}-config.cmake
     INSTALL_DESTINATION
-        ${CMAKE_INSTALL_DATADIR}/${PROJECT_NAME}/cmake
+        ${CMAKE_INSTALL_LIBDIR_ARCHIND}/cmake/${PROJECT_NAME}
     PATH_VARS
         BIN_INSTALL_DIR
         INCLUDE_INSTALL_DIR
@@ -278,7 +279,7 @@ install(
     DIRECTORY
         ${PROJECT_SOURCE_DIR}/thirdparty/cpp-peglib/
     DESTINATION
-        thirdparty/cpp-peglib/include
+        ${INCLUDE_INSTALL_DIR} # this is a hack, but it's still more appropriate than thirdparty
     FILES_MATCHING
         PATTERN "*.h"
     )
@@ -295,5 +296,5 @@ install(
         ${PROJECT_BINARY_DIR}/cmake/config/${PROJECT_NAME}-config.cmake
         ${PROJECT_BINARY_DIR}/cmake/config/${PROJECT_NAME}-config-version.cmake
     DESTINATION
-        ${DATA_INSTALL_DIR}/${PROJECT_NAME}/cmake
+        ${CMAKE_INSTALL_LIBDIR_ARCHIND}/cmake/${PROJECT_NAME}
     )

--- a/include/xtypes/DynamicDataImpl.hpp
+++ b/include/xtypes/DynamicDataImpl.hpp
@@ -142,10 +142,10 @@ inline std::string ReadableDynamicDataRef::to_string() const
                 ss << "<" << type_name << ">  " << node.data().value<char>();
                 break;
             case TypeKind::CHAR_16_TYPE:
-                ss << "<" << type_name << ">  " << node.data().value<char16_t>();
+                ss << "<" << type_name << ">  " << static_cast<int16_t>(node.data().value<char16_t>());
                 break;
             case TypeKind::WIDE_CHAR_TYPE:
-                ss << "<" << type_name << ">  " << node.data().value<wchar_t>();
+                ss << "<" << type_name << ">  " << static_cast<int32_t>(node.data().value<wchar_t>());
                 break;
             case TypeKind::INT_8_TYPE:
                 ss << "<" << type_name << ">  " << node.data().value<int8_t>();

--- a/include/xtypes/DynamicDataImpl.hpp
+++ b/include/xtypes/DynamicDataImpl.hpp
@@ -148,10 +148,10 @@ inline std::string ReadableDynamicDataRef::to_string() const
                 ss << "<" << type_name << ">  " << static_cast<int32_t>(node.data().value<wchar_t>());
                 break;
             case TypeKind::INT_8_TYPE:
-                ss << "<" << type_name << ">  " << node.data().value<int8_t>();
+                ss << "<" << type_name << ">  " << static_cast<int>(node.data().value<int8_t>());
                 break;
             case TypeKind::UINT_8_TYPE:
-                ss << "<" << type_name << ">  " << node.data().value<uint8_t>();
+                ss << "<" << type_name << ">  " << static_cast<int>(node.data().value<uint8_t>());
                 break;
             case TypeKind::INT_16_TYPE:
                 ss << "<" << type_name << ">  " << node.data().value<int16_t>();

--- a/include/xtypes/StringType.hpp
+++ b/include/xtypes/StringType.hpp
@@ -109,7 +109,7 @@ public:
     virtual void destroy_instance(
             uint8_t* instance) const override
     {
-        reinterpret_cast<std::basic_string<CHAR_T>*>(instance)->std::basic_string<CHAR_T>::~basic_string<CHAR_T>();
+        reinterpret_cast<std::basic_string<CHAR_T>*>(instance)->std::template basic_string<CHAR_T>::~basic_string<CHAR_T>();
     }
 
     virtual bool compare_instance(

--- a/include/xtypes/UnionType.hpp
+++ b/include/xtypes/UnionType.hpp
@@ -29,6 +29,7 @@
 #include <codecvt>
 #include <cwchar>
 #include <cuchar>
+#include <limits>
 
 namespace eprosima {
 namespace xtypes {

--- a/include/xtypes/idl/generator.hpp
+++ b/include/xtypes/idl/generator.hpp
@@ -242,14 +242,14 @@ inline std::string label_value(
         {
             char16_t temp = static_cast<char16_t>(value);
             std::stringstream ss;
-            ss << "L'" << temp << "'";
+            ss << "L'" << static_cast<int16_t>(temp) << "'";
             return ss.str();
         }
         case TypeKind::WIDE_CHAR_TYPE:
         {
             wchar_t temp = static_cast<wchar_t>(value);
             std::stringstream ss;
-            ss << "L'" << temp << "'";
+            ss << "L'" << static_cast<int32_t>(temp) << "'";
             return ss.str();
         }
         case TypeKind::INT_8_TYPE:

--- a/include/xtypes/idl/parser.hpp
+++ b/include/xtypes/idl/parser.hpp
@@ -284,8 +284,9 @@ public:
         , context_(nullptr)
     {
         parser_.enable_ast();
-        parser_.log = std::bind(&Parser::parser_log_cb_, this, std::placeholders::_1,
+        peg::Log log = std::bind(&Parser::parser_log_cb_, this, std::placeholders::_1,
                         std::placeholders::_2, std::placeholders::_3);
+        parser_.set_logger(log);
     }
 
     Context parse(
@@ -675,8 +676,9 @@ private:
             to_lower(aux_id);
         }
 
-        for (const std::string& name : parser_.get_rule_names())
+        for (const auto &item : parser_.get_grammar())
         {
+            const auto &name = item.first;
             if (name.find("KW_") == 0) // If it starts with "KW_", is a reserved word. You are welcome.
             {
                 if (parser_[name.c_str()].parse(aux_id.c_str()).ret)


### PR DESCRIPTION
This fixes the errors in #109.

Also includes #108 which should be merged first I guess. Then this can be rebased&merged.

I was not sure if casting the `char16_t`/`wchar_t` to ints is good enough for the string output. Perhaps someone could advise?

I also pinned cpp-peglib to what was the current version at the time because the API changed. I have updated to reflect the newer API but I don't think it should be set to trunk in case this happens again and break the build.
